### PR TITLE
feat: add account page and fix sign-in redirect flow

### DIFF
--- a/app/account/page.tsx
+++ b/app/account/page.tsx
@@ -1,0 +1,168 @@
+"use client";
+
+import { useAuth, useUser } from "@clerk/nextjs";
+import { useRouter } from "next/navigation";
+import Link from "next/link";
+import { useEffect } from "react";
+
+const WHATSAPP_URL = "https://wa.me/971582896090?text=Hi%20Ghali";
+
+export default function AccountPage() {
+  const { isSignedIn, isLoaded, signOut } = useAuth();
+  const { user } = useUser();
+  const router = useRouter();
+
+  const isAdmin =
+    isLoaded &&
+    isSignedIn &&
+    user &&
+    (user.publicMetadata as Record<string, unknown>)?.isAdmin === true;
+
+  useEffect(() => {
+    if (isLoaded && !isSignedIn) {
+      router.replace("/auth/admin-sign-in");
+    }
+  }, [isLoaded, isSignedIn, router]);
+
+  if (!isLoaded) {
+    return <div className="min-h-screen bg-[#0a0f1e]" />;
+  }
+
+  if (!isSignedIn) {
+    return null;
+  }
+
+  const identifier =
+    user?.primaryPhoneNumber?.phoneNumber ||
+    user?.primaryEmailAddress?.emailAddress ||
+    user?.fullName ||
+    "there";
+
+  return (
+    <div className="relative min-h-screen bg-[#0a0f1e] text-white">
+      {/* Subtle grid background */}
+      <div
+        className="pointer-events-none fixed inset-0 opacity-[0.03]"
+        style={{
+          backgroundImage:
+            "linear-gradient(rgba(255,255,255,0.1) 1px, transparent 1px), linear-gradient(90deg, rgba(255,255,255,0.1) 1px, transparent 1px)",
+          backgroundSize: "60px 60px",
+        }}
+      />
+
+      {/* Orange glow */}
+      <div className="pointer-events-none fixed top-1/3 left-1/2 h-[500px] w-[500px] -translate-x-1/2 -translate-y-1/2 rounded-full bg-[#ED6B23]/8 blur-[140px]" />
+
+      <main className="relative flex min-h-dvh flex-col items-center justify-center px-4 py-12 sm:px-6">
+        <div className="w-full max-w-md space-y-6">
+
+          {/* Header */}
+          <div className="text-center">
+            <div className="mb-4 inline-flex h-14 w-14 items-center justify-center rounded-2xl bg-[#ED6B23]/10 border border-[#ED6B23]/20">
+              <span className="text-2xl">🤖</span>
+            </div>
+            <h1 className="font-[family-name:var(--font-display)] text-3xl sm:text-4xl text-white">
+              Ghali
+            </h1>
+            <p className="mt-2 text-sm text-white/40">
+              Signed in as{" "}
+              <span className="text-white/60">{identifier}</span>
+            </p>
+          </div>
+
+          {/* Action cards */}
+          <div className="space-y-3">
+
+            {/* Manage Subscription */}
+            <Link
+              href="/upgrade"
+              className="group flex items-center gap-4 rounded-2xl border border-white/[0.08] bg-white/[0.03] p-5 transition-all hover:border-[#ED6B23]/30 hover:bg-[#ED6B23]/5"
+            >
+              <div className="flex h-11 w-11 flex-shrink-0 items-center justify-center rounded-xl bg-[#ED6B23]/10 border border-[#ED6B23]/20 text-xl transition-colors group-hover:bg-[#ED6B23]/20">
+                💳
+              </div>
+              <div className="min-w-0 flex-1">
+                <p className="font-semibold text-white">Manage Subscription</p>
+                <p className="mt-0.5 text-sm text-white/40">
+                  View plans, upgrade to Pro, or manage billing
+                </p>
+              </div>
+              <ChevronRightIcon className="h-4 w-4 flex-shrink-0 text-white/20 transition-colors group-hover:text-[#ED6B23]/60" />
+            </Link>
+
+            {/* Admin Dashboard — only for admins */}
+            {isAdmin && (
+              <Link
+                href="/admin"
+                className="group flex items-center gap-4 rounded-2xl border border-white/[0.08] bg-white/[0.03] p-5 transition-all hover:border-white/20 hover:bg-white/[0.06]"
+              >
+                <div className="flex h-11 w-11 flex-shrink-0 items-center justify-center rounded-xl bg-white/[0.06] border border-white/[0.08] text-xl transition-colors group-hover:bg-white/[0.1]">
+                  ⚙️
+                </div>
+                <div className="min-w-0 flex-1">
+                  <p className="font-semibold text-white">Admin Dashboard</p>
+                  <p className="mt-0.5 text-sm text-white/40">
+                    Users, stats, templates, and system settings
+                  </p>
+                </div>
+                <ChevronRightIcon className="h-4 w-4 flex-shrink-0 text-white/20 transition-colors group-hover:text-white/40" />
+              </Link>
+            )}
+
+            {/* Back to WhatsApp */}
+            <a
+              href={WHATSAPP_URL}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="group flex items-center gap-4 rounded-2xl border border-white/[0.08] bg-white/[0.03] p-5 transition-all hover:border-white/20 hover:bg-white/[0.06]"
+            >
+              <div className="flex h-11 w-11 flex-shrink-0 items-center justify-center rounded-xl bg-white/[0.06] border border-white/[0.08] text-xl transition-colors group-hover:bg-white/[0.1]">
+                💬
+              </div>
+              <div className="min-w-0 flex-1">
+                <p className="font-semibold text-white">Open WhatsApp</p>
+                <p className="mt-0.5 text-sm text-white/40">
+                  Chat with Ghali on WhatsApp
+                </p>
+              </div>
+              <ChevronRightIcon className="h-4 w-4 flex-shrink-0 text-white/20 transition-colors group-hover:text-white/40" />
+            </a>
+          </div>
+
+          {/* Sign out */}
+          <div className="flex items-center justify-center gap-4 pt-2">
+            <button
+              onClick={() => signOut({ redirectUrl: "/" })}
+              className="text-sm text-white/30 transition-colors hover:text-white/60"
+            >
+              Sign out
+            </button>
+            <span className="text-white/10">·</span>
+            <Link
+              href="/"
+              className="text-sm text-white/30 transition-colors hover:text-white/60"
+            >
+              Home
+            </Link>
+          </div>
+        </div>
+      </main>
+    </div>
+  );
+}
+
+function ChevronRightIcon({ className }: { className?: string }) {
+  return (
+    <svg
+      className={className}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={2}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
+      <path d="M9 18l6-6-6-6" />
+    </svg>
+  );
+}

--- a/app/auth/admin-sign-in/[[...sign-in]]/page.tsx
+++ b/app/auth/admin-sign-in/[[...sign-in]]/page.tsx
@@ -1,58 +1,34 @@
 "use client";
 
-import { SignIn, useAuth, useUser } from "@clerk/nextjs";
+import { SignIn, useAuth } from "@clerk/nextjs";
 import { useRouter } from "next/navigation";
-import Link from "next/link";
 import { useEffect } from "react";
 
 export default function AdminSignInPage() {
-  const { isSignedIn, signOut, isLoaded } = useAuth();
-  const { user } = useUser();
+  const { isSignedIn, isLoaded } = useAuth();
   const router = useRouter();
 
-  // Already signed in as admin — redirect to /admin
-  const isAdmin = isLoaded && isSignedIn && user && (user.publicMetadata as Record<string, unknown>)?.isAdmin === true;
+  // Already signed in — redirect to account page
   useEffect(() => {
-    if (isLoaded && isAdmin) {
-      router.replace("/admin");
+    if (isLoaded && isSignedIn) {
+      router.replace("/account");
     }
-  }, [isLoaded, isAdmin, router]);
+  }, [isLoaded, isSignedIn, router]);
 
   // Show blank page while Clerk is loading to prevent sign-in form flash
   if (!isLoaded) {
     return <div className="min-h-screen bg-[#0a0f1e]" />;
   }
 
-  // Already signed in but not admin — show message with sign-out option
-  if (isSignedIn && user && !isAdmin) {
-    return (
-      <div className="flex min-h-screen items-center justify-center bg-[#0a0f1e]">
-        <div className="w-full max-w-sm rounded-xl border border-white/[0.08] bg-[#0d1225]/90 p-8 text-center backdrop-blur-xl shadow-2xl">
-          <h2 className="text-lg font-semibold text-white">Access Denied</h2>
-          <p className="mt-2 text-sm text-white/50">
-            You&apos;re signed in as <span className="text-white/70">{user.primaryPhoneNumber?.phoneNumber || user.primaryEmailAddress?.emailAddress}</span> but this account doesn&apos;t have admin access.
-          </p>
-          <button
-            onClick={() => signOut({ redirectUrl: "/auth/admin-sign-in" })}
-            className="mt-6 w-full rounded-lg bg-[#ED6B23] px-4 py-2.5 text-sm font-medium text-white hover:bg-[#ED6B23]/90 transition-colors"
-          >
-            Sign out and try another account
-          </button>
-          <Link
-            href="/"
-            className="mt-3 block text-sm text-white/40 hover:text-white/60 transition-colors"
-          >
-            Back to home
-          </Link>
-        </div>
-      </div>
-    );
+  // Signed in — render nothing while redirect fires
+  if (isSignedIn) {
+    return <div className="min-h-screen bg-[#0a0f1e]" />;
   }
 
   return (
     <div className="flex min-h-screen items-center justify-center bg-[#0a0f1e]">
       <SignIn
-        forceRedirectUrl="/admin"
+        forceRedirectUrl="/account"
         appearance={{
           elements: {
             rootBox: "mx-auto",


### PR DESCRIPTION
Fixes #3

Create /account page as the unified post-sign-in destination. After signing in, all users (normal and admin) are redirected to /account instead of /admin. The account page shows a subscription management option for all users and conditionally shows an Admin Dashboard button only for users with isAdmin metadata.

Generated with [Claude Code](https://claude.ai/code)) · [View job run](https://github.com/ZenGardenDubai/ghali-ai-assistant/actions/runs/22357686964

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new account page displaying personalized user information with quick-action cards for managing subscriptions, accessing the admin dashboard (for administrators), and opening WhatsApp conversations.
  * Simplified authentication flow with updated redirects to route signed-in users to the account page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->