### PR TITLE
fix: prevent horizontal overflow on /features pages on mobile

### DIFF
--- a/app/components/landing/feature-page.tsx
+++ b/app/components/landing/feature-page.tsx
@@ -17,7 +17,7 @@ export function FeaturePage({
   jsonLd?: Record<string, unknown>;
 }) {
   return (
-    <div className="min-h-screen bg-[#0a0f1e] text-white">
+    <div className="min-h-screen overflow-x-hidden bg-[#0a0f1e] text-white">
       {jsonLd && (
         <script
           type="application/ld+json"

--- a/app/features/page.tsx
+++ b/app/features/page.tsx
@@ -117,7 +117,7 @@ const FEATURES = [
 
 export default function FeaturesPage() {
   return (
-    <div className="min-h-screen bg-[#0a0f1e] text-white">
+    <div className="min-h-screen overflow-x-hidden bg-[#0a0f1e] text-white">
       <script
         type="application/ld+json"
         dangerouslySetInnerHTML={{


### PR DESCRIPTION
Fixes #4

Adds `overflow-x-hidden` to the outer wrapper div on `/features` and all `/features/*` sub-pages to prevent decorative blur elements (`w-[500px]`) from causing horizontal layout shift on mobile viewports narrower than 500px.

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed horizontal scrolling on feature pages caused by content exceeding the viewport width.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->