### PR TITLE
feat: add Dubai-timezone daily stats alongside rolling 24h stats

### DIFF
--- a/convex/lib/adminCommands.ts
+++ b/convex/lib/adminCommands.ts
@@ -65,6 +65,10 @@ export async function handleAdminCommand(
         activeWeek: number;
         activeMonth: number;
         newToday: number;
+        activeTodayDubai: number;
+        activeWeekDubai: number;
+        activeMonthDubai: number;
+        newTodayDubai: number;
         proUsers: number;
       };
       return {
@@ -76,6 +80,10 @@ export async function handleAdminCommand(
             activeWeek: stats.activeWeek,
             activeMonth: stats.activeMonth,
             newToday: stats.newToday,
+            activeTodayDubai: stats.activeTodayDubai,
+            activeWeekDubai: stats.activeWeekDubai,
+            activeMonthDubai: stats.activeMonthDubai,
+            newTodayDubai: stats.newTodayDubai,
             proUsers: stats.proUsers,
           },
           userMessage

--- a/convex/lib/dateUtils.test.ts
+++ b/convex/lib/dateUtils.test.ts
@@ -1,0 +1,130 @@
+import { describe, it, expect } from "vitest";
+import { getDubaiMidnightMs, getDubaiWeekStartMs, getDubaiMonthStartMs } from "./dateUtils";
+
+/**
+ * Dubai is UTC+4 (no DST).
+ * Midnight in Dubai = 20:00 UTC the previous day.
+ *
+ * Reference dates used in tests:
+ *   2024-01-14 = Sunday
+ *   2024-01-15 = Monday
+ *   2024-01-17 = Wednesday
+ *   2024-01-20 = Saturday
+ */
+
+describe("getDubaiMidnightMs", () => {
+  it("returns midnight of the current Dubai day given a midday UTC timestamp", () => {
+    // 2024-01-15T08:00:00Z = 2024-01-15T12:00:00+04:00 (midday Monday in Dubai)
+    const input = new Date("2024-01-15T08:00:00Z").getTime();
+    const midnight = getDubaiMidnightMs(input);
+    // Midnight Monday Dubai = 2024-01-15T00:00:00+04:00 = 2024-01-14T20:00:00Z
+    expect(midnight).toBe(new Date("2024-01-14T20:00:00Z").getTime());
+  });
+
+  it("returns the same day midnight when time is 02:00 Dubai (past midnight)", () => {
+    // 2024-01-15T02:00:00+04:00 = 2024-01-14T22:00:00Z
+    const input = new Date("2024-01-14T22:00:00Z").getTime();
+    const midnight = getDubaiMidnightMs(input);
+    // Midnight on 2024-01-15 in Dubai = 2024-01-14T20:00:00Z
+    expect(midnight).toBe(new Date("2024-01-14T20:00:00Z").getTime());
+  });
+
+  it("returns the exact millisecond when called with midnight itself", () => {
+    // 2024-01-15T00:00:00+04:00 = 2024-01-14T20:00:00Z
+    const dubaiMidnight = new Date("2024-01-14T20:00:00Z").getTime();
+    expect(getDubaiMidnightMs(dubaiMidnight)).toBe(dubaiMidnight);
+  });
+
+  it("handles 23:59 Dubai correctly (still same day)", () => {
+    // 2024-01-15T23:59:00+04:00 = 2024-01-15T19:59:00Z
+    const input = new Date("2024-01-15T19:59:00Z").getTime();
+    const midnight = getDubaiMidnightMs(input);
+    // Still Monday Jan 15 Dubai → midnight = 2024-01-14T20:00:00Z
+    expect(midnight).toBe(new Date("2024-01-14T20:00:00Z").getTime());
+  });
+
+  it("rolls over to next day at midnight UTC+4", () => {
+    // One second before midnight Dubai = 2024-01-15T23:59:59+04:00 = 2024-01-15T19:59:59Z
+    const beforeMidnight = new Date("2024-01-15T19:59:59Z").getTime();
+    // One second after midnight Dubai = 2024-01-16T00:00:01+04:00 = 2024-01-15T20:00:01Z
+    const afterMidnight = new Date("2024-01-15T20:00:01Z").getTime();
+
+    const midnightBefore = getDubaiMidnightMs(beforeMidnight);
+    const midnightAfter = getDubaiMidnightMs(afterMidnight);
+
+    expect(midnightBefore).toBe(new Date("2024-01-14T20:00:00Z").getTime()); // Jan 15 midnight
+    expect(midnightAfter).toBe(new Date("2024-01-15T20:00:00Z").getTime());  // Jan 16 midnight
+  });
+});
+
+describe("getDubaiWeekStartMs", () => {
+  it("returns Sunday midnight when today is Wednesday", () => {
+    // 2024-01-17 is a Wednesday in Dubai
+    // 2024-01-17T08:00:00Z = 2024-01-17T12:00:00+04:00
+    const wednesday = new Date("2024-01-17T08:00:00Z").getTime();
+    const weekStart = getDubaiWeekStartMs(wednesday);
+    // Sunday 2024-01-14 midnight Dubai = 2024-01-13T20:00:00Z
+    expect(weekStart).toBe(new Date("2024-01-13T20:00:00Z").getTime());
+  });
+
+  it("returns today's midnight when today is Sunday", () => {
+    // 2024-01-14 is a Sunday
+    // 2024-01-14T08:00:00Z = 2024-01-14T12:00:00+04:00
+    const sunday = new Date("2024-01-14T08:00:00Z").getTime();
+    const weekStart = getDubaiWeekStartMs(sunday);
+    // Sunday 2024-01-14 midnight Dubai = 2024-01-13T20:00:00Z
+    expect(weekStart).toBe(new Date("2024-01-13T20:00:00Z").getTime());
+  });
+
+  it("returns 6 days ago midnight when today is Saturday", () => {
+    // 2024-01-20 is a Saturday
+    // 2024-01-20T08:00:00Z = 2024-01-20T12:00:00+04:00
+    const saturday = new Date("2024-01-20T08:00:00Z").getTime();
+    const weekStart = getDubaiWeekStartMs(saturday);
+    // Sunday 2024-01-14 midnight Dubai = 2024-01-13T20:00:00Z
+    expect(weekStart).toBe(new Date("2024-01-13T20:00:00Z").getTime());
+  });
+
+  it("returns 1 day ago midnight when today is Monday", () => {
+    // 2024-01-15 is a Monday
+    // 2024-01-15T08:00:00Z = 2024-01-15T12:00:00+04:00
+    const monday = new Date("2024-01-15T08:00:00Z").getTime();
+    const weekStart = getDubaiWeekStartMs(monday);
+    // Sunday 2024-01-14 midnight Dubai = 2024-01-13T20:00:00Z
+    expect(weekStart).toBe(new Date("2024-01-13T20:00:00Z").getTime());
+  });
+});
+
+describe("getDubaiMonthStartMs", () => {
+  it("returns 1st of January midnight Dubai for mid-January date", () => {
+    // 2024-01-15T08:00:00Z = 2024-01-15T12:00:00+04:00
+    const midJan = new Date("2024-01-15T08:00:00Z").getTime();
+    const monthStart = getDubaiMonthStartMs(midJan);
+    // 2024-01-01T00:00:00+04:00 = 2023-12-31T20:00:00Z
+    expect(monthStart).toBe(new Date("2023-12-31T20:00:00Z").getTime());
+  });
+
+  it("returns same day midnight when today is the 1st", () => {
+    // 2024-01-01T08:00:00Z = 2024-01-01T12:00:00+04:00
+    const firstDay = new Date("2024-01-01T08:00:00Z").getTime();
+    const monthStart = getDubaiMonthStartMs(firstDay);
+    // 2024-01-01T00:00:00+04:00 = 2023-12-31T20:00:00Z
+    expect(monthStart).toBe(new Date("2023-12-31T20:00:00Z").getTime());
+  });
+
+  it("returns 1st of February midnight Dubai for mid-February date", () => {
+    // 2024-02-15T08:00:00Z = 2024-02-15T12:00:00+04:00
+    const febMid = new Date("2024-02-15T08:00:00Z").getTime();
+    const monthStart = getDubaiMonthStartMs(febMid);
+    // 2024-02-01T00:00:00+04:00 = 2024-01-31T20:00:00Z
+    expect(monthStart).toBe(new Date("2024-01-31T20:00:00Z").getTime());
+  });
+
+  it("handles December correctly (no year rollover issue)", () => {
+    // 2024-12-15T08:00:00Z = 2024-12-15T12:00:00+04:00
+    const decMid = new Date("2024-12-15T08:00:00Z").getTime();
+    const monthStart = getDubaiMonthStartMs(decMid);
+    // 2024-12-01T00:00:00+04:00 = 2024-11-30T20:00:00Z
+    expect(monthStart).toBe(new Date("2024-11-30T20:00:00Z").getTime());
+  });
+});

--- a/convex/lib/dateUtils.ts
+++ b/convex/lib/dateUtils.ts
@@ -1,0 +1,73 @@
+/**
+ * Pure Dubai-timezone date boundary utilities.
+ * Dubai is UTC+4 with no daylight saving time.
+ * All functions accept a Unix timestamp in milliseconds and return one.
+ */
+
+const DUBAI_TZ = "Asia/Dubai"; // UTC+4, no DST
+const MS_PER_DAY = 24 * 60 * 60 * 1000;
+
+/**
+ * Returns midnight (00:00:00) of the current Dubai calendar day
+ * for the given Unix timestamp, expressed as a UTC Unix timestamp in ms.
+ *
+ * Example: 2024-01-15T12:00:00+04:00 → 2024-01-15T00:00:00+04:00 = 2024-01-14T20:00:00Z
+ */
+export function getDubaiMidnightMs(now: number = Date.now()): number {
+  const parts = new Intl.DateTimeFormat("en-US", {
+    timeZone: DUBAI_TZ,
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+  }).formatToParts(new Date(now));
+
+  const year = parts.find((p) => p.type === "year")!.value;
+  const month = parts.find((p) => p.type === "month")!.value;
+  const day = parts.find((p) => p.type === "day")!.value;
+
+  // Construct ISO 8601 string anchored to Dubai midnight
+  return new Date(`${year}-${month}-${day}T00:00:00+04:00`).getTime();
+}
+
+/**
+ * Returns the start of the current Dubai calendar week (Sunday at 00:00 UTC+4)
+ * for the given Unix timestamp, expressed as a UTC Unix timestamp in ms.
+ *
+ * Week starts on Sunday per UAE convention.
+ */
+export function getDubaiWeekStartMs(now: number = Date.now()): number {
+  const dayName = new Intl.DateTimeFormat("en-US", {
+    timeZone: DUBAI_TZ,
+    weekday: "short",
+  }).format(new Date(now));
+
+  const dayOffset: Record<string, number> = {
+    Sun: 0,
+    Mon: 1,
+    Tue: 2,
+    Wed: 3,
+    Thu: 4,
+    Fri: 5,
+    Sat: 6,
+  };
+
+  const offset = dayOffset[dayName] ?? 0;
+  return getDubaiMidnightMs(now) - offset * MS_PER_DAY;
+}
+
+/**
+ * Returns the start of the current Dubai calendar month (1st at 00:00 UTC+4)
+ * for the given Unix timestamp, expressed as a UTC Unix timestamp in ms.
+ */
+export function getDubaiMonthStartMs(now: number = Date.now()): number {
+  const parts = new Intl.DateTimeFormat("en-US", {
+    timeZone: DUBAI_TZ,
+    year: "numeric",
+    month: "2-digit",
+  }).formatToParts(new Date(now));
+
+  const year = parts.find((p) => p.type === "year")!.value;
+  const month = parts.find((p) => p.type === "month")!.value;
+
+  return new Date(`${year}-${month}-01T00:00:00+04:00`).getTime();
+}

--- a/convex/templates.ts
+++ b/convex/templates.ts
@@ -281,13 +281,30 @@ Your account and credits remain. Say hi to start fresh 👋`,
   admin_stats: {
     template: `*Platform Stats* 📊
 
-*Total Users:* {{totalUsers}}
-*Active Today:* {{activeToday}}
-*Active This Week:* {{activeWeek}}
-*Active This Month:* {{activeMonth}}
-*New Today:* {{newToday}}
-*Pro Users:* {{proUsers}}`,
-    variables: ["totalUsers", "activeToday", "activeWeek", "activeMonth", "newToday", "proUsers"],
+*Today (Dubai time, UTC+4)*
+New: {{newTodayDubai}} | Active: {{activeTodayDubai}}
+
+*Last 24 Hours (rolling)*
+New: {{newToday}} | Active: {{activeToday}}
+
+*This Week (Dubai, starts Sun)*
+Active: {{activeWeekDubai}}
+
+*This Month (Dubai)*
+Active: {{activeMonthDubai}}
+
+*All Time*
+Total: {{totalUsers}} | Pro: {{proUsers}}`,
+    variables: [
+      "newTodayDubai",
+      "activeTodayDubai",
+      "newToday",
+      "activeToday",
+      "activeWeekDubai",
+      "activeMonthDubai",
+      "totalUsers",
+      "proUsers",
+    ],
   },
 
   admin_search_result: {


### PR DESCRIPTION
Adds Dubai-timezone (UTC+4) calendar-anchored stats alongside the existing rolling window stats in the admin `stats` command.

## Changes
- New `convex/lib/dateUtils.ts` with pure `getDubaiMidnightMs`, `getDubaiWeekStartMs`, `getDubaiMonthStartMs` functions
- 13 unit tests in `convex/lib/dateUtils.test.ts`
- `getStats` query now returns both rolling and Dubai-anchored metrics
- `admin_stats` template shows Today (Dubai time) vs Last 24 Hours (rolling), with weekly/monthly anchored to Dubai timezone (week starts Sunday, month starts 1st at 00:00 UTC+4)

Closes #10

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Dubai timezone-specific metrics to the admin dashboard, including daily, weekly, and monthly active users and new user counts calculated based on Dubai local time (UTC+4).
  * Redesigned the admin stats display with distinct sections separating Dubai calendar-based metrics from rolling 24-hour and all-time statistics.

* **Tests**
  * Added comprehensive test coverage for Dubai timezone date utility functions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->