### PR TITLE
fix: use RELEASE_PLEASE_TOKEN in CI workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,11 @@
 name: CI
 
 on:
+  push:
+    branches: [main]
   pull_request:
     branches: [main]
+  workflow_dispatch:
 
 jobs:
   lint-and-typecheck:

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -15,6 +15,6 @@ jobs:
     steps:
       - uses: googleapis/release-please-action@v4
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.RELEASE_PLEASE_TOKEN || secrets.GITHUB_TOKEN }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json


### PR DESCRIPTION
## Summary
- Use `RELEASE_PLEASE_TOKEN` PAT (with `GITHUB_TOKEN` fallback) in release-please workflow so PRs trigger CI checks
- Add `push` on main and `workflow_dispatch` triggers to CI workflow for post-merge runs and manual re-triggers

Closes #16

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Enhanced CI/CD pipeline to automatically run on main branch pushes and support manual workflow triggers.
  * Improved release automation with enhanced token handling and fallback support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->