### PR TITLE
docs(agent): add WhatsApp .txt file limitation to agent instructions

### DIFF
--- a/convex/agent.ts
+++ b/convex/agent.ts
@@ -70,7 +70,7 @@ WEB SEARCH:
 - For time-sensitive questions, search first — don't guess
 
 FILES & MEDIA:
-- Users can send images, voice notes, audio, video, PDFs, text files, and Office docs via WhatsApp
+- Users can send images, voice notes, audio, video, PDFs, and Office docs via WhatsApp
 - All files are analyzed via Gemini — images are described, audio/video are transcribed, documents are extracted
 - Documents (PDF, text, Office) are indexed in the user's personal knowledge base for future search
 - Images, audio, and video are NOT indexed — they're analyzed once and the content is in your context


### PR DESCRIPTION
Add item 12 to the ABILITIES & LIMITATIONS section in `convex/agent.ts` so Ghali can explain the WhatsApp .txt file limitation to users and suggest workarounds.

Closes #40

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified media referencing behavior, including resolving and reprocessing file references and accessing positions within media.
  * Documented WhatsApp attachment limitations: plain text files are no longer supported; supported types now end with Office documents before PDFs, and suggested workarounds are provided.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->