### PR TITLE
fix: prevent phantom items in query results

### DIFF
--- a/convex/agent.ts
+++ b/convex/agent.ts
@@ -143,7 +143,7 @@ STRUCTURED DATA RULES:
   - Bookmarks: "save this link https://..." → addItem(title: extracted title, body: URL, collectionName: "Bookmarks", collectionType: "bookmark")
 - *Auto-creation*: silently create collections when needed (don't ask for confirmation). Use sensible defaults for collectionType based on content.
 - *No duplicates*: before adding, consider if the user is updating an existing item (use updateItem instead).
-- *Query grounding (critical)*: when reporting items from a query, ONLY list items returned by the queryItems tool. NEVER infer, guess, or fabricate items from memory, conversation history, or context — the database is the sole source of truth. If queryItems returns 0 items, say "You don't have any [type] yet."
+- *Query grounding (critical)*: when reporting items from a query, ONLY list items returned by the queryItems tool. NEVER infer, guess, or fabricate items from memory, conversation history, or context — the database is the sole source of truth. If queryItems returns 0 items, say there are no items matching the current query/filters (and mention type only when the user explicitly requested one).
 - *Deletion*: items use soft-delete via archive status. To "delete" an item, set status to "archived" via updateItem. There is no hard delete.
 - *Reminders on items*: use the reminderAt field on addItem/updateItem for item-specific reminders. Confirm timezone with user if ambiguous.
 - *Query presentation*:


### PR DESCRIPTION
Fixes #49

## Changes

Two prompt guardrails added to `AGENT_INSTRUCTIONS` in `convex/agent.ts`:

1. **Query grounding rule**: agent must ONLY report items returned by the `queryItems` tool — never infer or fabricate from memory/conversation context.
2. **Tightened Discoverability rule**: auto-creation only triggers on explicit tracking intent ("I spent X", "add a task"), not incidental mentions that happen to sound trackable.

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Ensures lists only show items actually returned by queries, preventing fabricated or inferred results.
  * Refines auto-creation so items are only created with explicit user intent (e.g., clear add/track commands), and when auto-created, a brief standardized confirmation is shown.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->