### PR TITLE
fix: use PAT for Claude workflow to trigger CI on PRs

### DIFF
--- a/.github/workflows/claude-interactive.yml
+++ b/.github/workflows/claude-interactive.yml
@@ -51,7 +51,7 @@ jobs:
         uses: anthropics/claude-code-action@v1
         timeout-minutes: 25
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          github_token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
 
           max_turns: "25"


### PR DESCRIPTION
## Problem
The Claude Interactive workflow uses `GITHUB_TOKEN`, which prevents GitHub Actions CI from triggering on PRs that Claude creates. This is a known GitHub limitation — workflows triggered by `GITHUB_TOKEN` events don't trigger other workflows.

## Fix
Switch to `RELEASE_PLEASE_TOKEN` (a PAT already configured as a repo secret) so that when Claude pushes commits or opens PRs, the CI workflow (lint, typecheck, test, build) runs automatically.

## One-line change
```yaml
- github_token: ${{ secrets.GITHUB_TOKEN }}
+ github_token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflow configuration for internal processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->