### PR TITLE
fix: improve scheduled task execution prompt

### DIFF
--- a/convex/scheduledTasks.test.ts
+++ b/convex/scheduledTasks.test.ts
@@ -612,6 +612,8 @@ describe("buildScheduledTaskPrompt", () => {
     expect(result).toContain("User context here");
     expect(result).toContain("Daily joke");
     expect(result).toContain("Tell me a joke");
+    expect(result).toContain("<scheduled_task_instructions>");
+    expect(result).toContain("Focus ONLY on this task");
   });
 
   it("builds prompt without user context", () => {
@@ -620,6 +622,7 @@ describe("buildScheduledTaskPrompt", () => {
       ""
     );
     expect(result).toContain("<scheduled_task>");
+    expect(result).toContain("<scheduled_task_instructions>");
     expect(result).not.toContain("---");
   });
 
@@ -629,6 +632,14 @@ describe("buildScheduledTaskPrompt", () => {
       "context"
     );
     expect(result).toContain("Delivery format: bullet points");
+  });
+
+  it("instructs agent to use language from user files", () => {
+    const result = buildScheduledTaskPrompt(
+      { title: "News", description: "Get news" },
+      "context"
+    );
+    expect(result).toContain("Respond in the user's preferred language");
   });
 });
 
@@ -649,3 +660,4 @@ describe("truncateForTemplate", () => {
     expect(truncateForTemplate(exact, 100)).toBe(exact);
   });
 });
+

--- a/convex/scheduledTasks.ts
+++ b/convex/scheduledTasks.ts
@@ -28,9 +28,19 @@ export function buildScheduledTaskPrompt(
     ? `${task.description}\n\nDelivery format: ${task.deliveryFormat}`
     : task.description;
 
+  const instructions = `\n<scheduled_task_instructions>
+You are executing a scheduled task. RULES:
+- Focus ONLY on this task. Do NOT call listScheduledTasks or manage other tasks.
+- Do NOT mention other scheduled tasks the user has.
+- Deliver the task result directly — no preamble like "Here's your scheduled task result".
+- If this is a reminder, deliver a short, friendly reminder message.
+- If this is a briefing/report, deliver the content directly.
+- Respond in the user's preferred language (from their personality/memory above).
+</scheduled_task_instructions>`;
+
   return userContext
-    ? `${userContext}\n\n---\n<scheduled_task>\nTitle: ${task.title}\n${taskPrompt}\n</scheduled_task>`
-    : `<scheduled_task>\nTitle: ${task.title}\n${taskPrompt}\n</scheduled_task>`;
+    ? `${userContext}\n\n---${instructions}\n<scheduled_task>\nTitle: ${task.title}\n${taskPrompt}\n</scheduled_task>`
+    : `${instructions}\n<scheduled_task>\nTitle: ${task.title}\n${taskPrompt}\n</scheduled_task>`;
 }
 
 /**
@@ -245,7 +255,7 @@ export const executeScheduledTask = internalAction({
       userId: task.userId as string,
     });
 
-    // Build prompt
+    // Build prompt (personality/memory language preferences are in userContext)
     const fullPrompt = buildScheduledTaskPrompt(task, userContext);
 
     // Run agent


### PR DESCRIPTION
## Summary
- Add `<scheduled_task_instructions>` block to scheduled task prompts to guide agent behavior during execution
- Agent now focuses only on the current task instead of calling `listScheduledTasks` and showing all tasks
- Agent respects user's language preference from personality/memory files instead of ignoring it

## Problems fixed
1. **Water reminder not delivered** — agent called `listScheduledTasks` and returned a task list instead of delivering the reminder
2. **Task list shown at execution time** — same root cause as above
3. **News briefing in wrong language** — agent ignored user's English preference and responded in Arabic

## Test plan
- [x] All 631 tests pass
- [ ] Create a one-off reminder via WhatsApp, verify it delivers the reminder message (not a task list)
- [ ] Create a news briefing task, verify it responds in the user's preferred language
- [ ] Verify agent doesn't mention other scheduled tasks during execution

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Enhanced scheduled task execution with clearer instruction handling
  * Ensured scheduled tasks respect user's preferred language settings

* **Tests**
  * Added validation tests for scheduled task prompt instructions and language preference behavior

<!-- end of auto-generated comment: release notes by coderabbit.ai -->