### PR TITLE
fix: track deep reasoning (Opus) as $ai_generation events

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,6 @@ yarn-error.log*
 # typescript
 *.tsbuildinfo
 next-env.d.ts
+
+# google ads setup (private)
+docs/GOOGLE-ADS-SETUP.md

--- a/convex/agent.ts
+++ b/convex/agent.ts
@@ -306,7 +306,7 @@ Rules:
         prompt: task,
       });
 
-      // Track feature_used for deep reasoning
+      // Track feature_used + $ai_generation for deep reasoning
       const userId = ctx.userId as Id<"users">;
       const user = await ctx.runQuery(internal.users.internalGetUser, { userId }) as {
         phone: string; tier: string;
@@ -315,6 +315,14 @@ Rules:
         await ctx.scheduler.runAfter(0, internal.analytics.trackFeatureUsed, {
           phone: user.phone,
           feature: "deep_reasoning",
+          tier: user.tier,
+        });
+        await ctx.scheduler.runAfter(0, internal.analytics.trackAIGeneration, {
+          phone: user.phone,
+          model: MODELS.DEEP_REASONING,
+          provider: "anthropic",
+          promptTokens: result.usage?.inputTokens ?? 0,
+          completionTokens: result.usage?.outputTokens ?? 0,
           tier: user.tier,
         });
       }


### PR DESCRIPTION
## Summary
- The `deepReasoning` tool (Claude Opus 4.6) was only sending `feature_used` analytics but not `$ai_generation`, making Opus calls invisible in the "Model Usage Breakdown" PostHog insight
- Added `trackAIGeneration` call with model, provider, and token counts alongside the existing `trackFeatureUsed`
- Also gitignored `docs/GOOGLE-ADS-SETUP.md` (private Google Ads campaign setup notes)

## Test plan
- [x] `npx convex typecheck` passes
- [x] All 635 tests pass
- [ ] After deploy: trigger a deep reasoning call and verify `$ai_generation` event appears in PostHog with `$ai_model: claude-opus-4-6`
- [ ] Verify the "Model Usage Breakdown" insight shows Opus alongside Flash/Embeddings/Image Gen

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved analytics tracking for AI generation metrics and token usage monitoring

<!-- end of auto-generated comment: release notes by coderabbit.ai -->