### PR TITLE
fix(items): sort queryItems results newest-first

### DIFF
--- a/convex/items.ts
+++ b/convex/items.ts
@@ -485,7 +485,10 @@ export const queryItems = internalQuery({
       items = items.filter((i) => i._creationTime <= dateTo);
     }
 
-    return items.slice(0, queryLimit);
+    // Return newest items first so recently added items are always visible
+    return items
+      .sort((a, b) => b._creationTime - a._creationTime)
+      .slice(0, queryLimit);
   },
 });
 


### PR DESCRIPTION
Fixes #98

Sorts items by `_creationTime` descending in `queryItems` so recently added notes always appear at the top of results instead of being pushed off by older items.

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Items are now returned in newest-first order.

* **Tests**
  * Added tests to verify items are returned in correct order.
  * Added tests to ensure newest items are preserved when limits are applied.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->