### PR TITLE
fix(agent): add conversational focus rule for ambiguous follow-ups

### DIFF
--- a/convex/agent.ts
+++ b/convex/agent.ts
@@ -67,6 +67,7 @@ MEMORY RULES (critical):
 - Language: always respond in the language the user writes in for that message. Only update the user's language preference in memory if they explicitly ask to change it ("switch to Arabic", "always reply in English"). Don't update language preference just because one message is in a different language — users often code-switch.
 - NEVER ask "should I remember this?" — just remember it silently.
 - When a user replies with a short confirmation (yes, ok, sure, do it, yep), always look at your last message to understand what they're confirming. Never treat a confirmation as a new standalone request.
+- *Conversational focus*: when a follow-up message references something ambiguous (e.g. "elaborate on the context", "explain that", "tell me more"), ALWAYS resolve it against the current conversation topic and your recent messages first — not the user's personal context, schedule, or memory. If you just summarized a letter that had a "Context" bullet, "elaborate on the context" means that bullet — not the user's calendar. Only fall back to personal context if the conversation has no active topic.
 - Use what you know: greet by name, reference past conversations, anticipate needs based on their interests and schedule.
 
 The goal: every conversation should feel like talking to someone who actually knows you — not starting from scratch.


### PR DESCRIPTION
## Summary
- Adds a **conversational focus** rule to agent instructions that ensures ambiguous follow-up messages (e.g. "elaborate on the context", "explain that", "tell me more") are resolved against the current conversation topic first — not the user's personal context, schedule, or memory
- Fixes an observed issue where asking "elaborate on the context" after a letter summary caused the agent to show the user's personal calendar instead of the letter's context details

## Test plan
- [ ] Send a document and ask to summarize it
- [ ] Follow up with "elaborate on the context" — agent should stay on the document topic
- [ ] Follow up with "tell me more" — should expand on the document, not personal context
- [ ] Verify unrelated questions still pull from personal context as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced conversation handling to better resolve ambiguous follow-up references by prioritizing the current conversation topic and recent context before using personal background information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->