### PR TITLE
fix(admin): show rolling 7d/30d stats and consolidate duplicate queries

### DIFF
--- a/convex/admin.ts
+++ b/convex/admin.ts
@@ -49,16 +49,23 @@ export const TEMPLATE_DEFINITIONS = [
 
 /**
  * Get platform-wide stats for admin dashboard.
+ * Used by both the WhatsApp `admin stats` command and the HTTP `/admin/stats` endpoint.
+ *
+ * Rolling windows: from (now - X) to now, regardless of calendar day.
+ * Dubai calendar windows: from the start of the current Dubai day/week/month (UTC+4).
+ * Yesterday window: from (now - 48h) to (now - 24h), for period-specific comparisons.
  */
 export const getStats = internalQuery({
   args: {},
   handler: async (ctx) => {
     const now = Date.now();
+    const DAY = 24 * 60 * 60 * 1000;
 
-    // Rolling windows
-    const oneDayAgo = now - 24 * 60 * 60 * 1000;
-    const oneWeekAgo = now - 7 * 24 * 60 * 60 * 1000;
-    const oneMonthAgo = now - 30 * 24 * 60 * 60 * 1000;
+    // Rolling windows (from now - X to now)
+    const oneDayAgo = now - DAY;
+    const twoDaysAgo = now - 2 * DAY;
+    const oneWeekAgo = now - 7 * DAY;
+    const oneMonthAgo = now - 30 * DAY;
 
     // Dubai-anchored boundaries (UTC+4, week starts Sunday, month starts 1st)
     const dubaiDayStart = getDubaiMidnightMs(now);
@@ -68,8 +75,10 @@ export const getStats = internalQuery({
     const allUsers = await ctx.db.query("users").collect();
 
     const totalUsers = allUsers.length;
+    const proUsers = allUsers.filter((u) => u.tier === "pro").length;
+    const basicUsers = allUsers.filter((u) => u.tier === "basic").length;
 
-    // Rolling window stats
+    // Rolling window active stats (users who sent a message in the last X hours/days)
     const activeToday = allUsers.filter(
       (u) => u.lastMessageAt && u.lastMessageAt >= oneDayAgo
     ).length;
@@ -79,11 +88,21 @@ export const getStats = internalQuery({
     const activeMonth = allUsers.filter(
       (u) => u.lastMessageAt && u.lastMessageAt >= oneMonthAgo
     ).length;
-    const newToday = allUsers.filter(
-      (u) => u.createdAt >= oneDayAgo
+
+    // Rolling new users (accounts created in the last X hours/days)
+    const newToday = allUsers.filter((u) => u.createdAt >= oneDayAgo).length;
+    const newWeek = allUsers.filter((u) => u.createdAt >= oneWeekAgo).length;
+    const newMonth = allUsers.filter((u) => u.createdAt >= oneMonthAgo).length;
+
+    // Yesterday window (24h–48h ago) — for period-specific dashboard comparisons
+    const activeYesterday = allUsers.filter(
+      (u) => u.lastMessageAt && u.lastMessageAt >= twoDaysAgo && u.lastMessageAt < oneDayAgo
+    ).length;
+    const newYesterday = allUsers.filter(
+      (u) => u.createdAt >= twoDaysAgo && u.createdAt < oneDayAgo
     ).length;
 
-    // Dubai calendar-day stats
+    // Dubai calendar-day stats (anchored to Dubai midnight/week-start/month-start)
     const activeTodayDubai = allUsers.filter(
       (u) => u.lastMessageAt && u.lastMessageAt >= dubaiDayStart
     ).length;
@@ -97,19 +116,25 @@ export const getStats = internalQuery({
       (u) => u.createdAt >= dubaiDayStart
     ).length;
 
-    const proUsers = allUsers.filter((u) => u.tier === "pro").length;
-
     return {
       totalUsers,
+      proUsers,
+      basicUsers,
+      // Rolling windows
       activeToday,
       activeWeek,
       activeMonth,
       newToday,
+      newWeek,
+      newMonth,
+      // Yesterday window
+      activeYesterday,
+      newYesterday,
+      // Dubai calendar-day stats
       activeTodayDubai,
       activeWeekDubai,
       activeMonthDubai,
       newTodayDubai,
-      proUsers,
     };
   },
 });
@@ -215,46 +240,6 @@ export const getAllUsers = internalQuery({
   args: {},
   handler: async (ctx) => {
     return await ctx.db.query("users").collect();
-  },
-});
-
-/**
- * Period-aware dashboard stats.
- */
-export const getDashboardStats = internalQuery({
-  args: { period: v.union(v.literal("today"), v.literal("yesterday"), v.literal("7d"), v.literal("30d")) },
-  handler: async (ctx, { period }) => {
-    const now = Date.now();
-    const DAY = 24 * 60 * 60 * 1000;
-
-    let start: number;
-    let end: number = now;
-    switch (period) {
-      case "today":
-        start = now - DAY;
-        break;
-      case "yesterday":
-        start = now - 2 * DAY;
-        end = now - DAY;
-        break;
-      case "7d":
-        start = now - 7 * DAY;
-        break;
-      case "30d":
-        start = now - 30 * DAY;
-        break;
-    }
-
-    const allUsers = await ctx.db.query("users").collect();
-    const totalUsers = allUsers.length;
-    const newUsers = allUsers.filter((u) => u.createdAt >= start && u.createdAt < end).length;
-    const activeUsers = allUsers.filter(
-      (u) => u.lastMessageAt && u.lastMessageAt >= start && u.lastMessageAt < end
-    ).length;
-    const proUsers = allUsers.filter((u) => u.tier === "pro").length;
-    const basicUsers = allUsers.filter((u) => u.tier === "basic").length;
-
-    return { totalUsers, newUsers, activeUsers, proUsers, basicUsers };
   },
 });
 

--- a/convex/http.ts
+++ b/convex/http.ts
@@ -308,13 +308,37 @@ http.route({
     if (!VALID_PERIODS.has(period)) {
       return new Response("Invalid period", { status: 400 });
     }
-    const result = await ctx.runQuery(internal.admin.getDashboardStats, {
-      period: period as "today" | "yesterday" | "7d" | "30d",
-    });
-    return new Response(JSON.stringify(result), {
-      status: 200,
-      headers: { "Content-Type": "application/json" },
-    });
+    const all = await ctx.runQuery(internal.admin.getStats, {});
+    // Map the consolidated stats snapshot to the period-specific response shape.
+    let newUsers: number;
+    let activeUsers: number;
+    switch (period) {
+      case "yesterday":
+        newUsers = all.newYesterday;
+        activeUsers = all.activeYesterday;
+        break;
+      case "7d":
+        newUsers = all.newWeek;
+        activeUsers = all.activeWeek;
+        break;
+      case "30d":
+        newUsers = all.newMonth;
+        activeUsers = all.activeMonth;
+        break;
+      default: // "today"
+        newUsers = all.newToday;
+        activeUsers = all.activeToday;
+    }
+    return new Response(
+      JSON.stringify({
+        totalUsers: all.totalUsers,
+        newUsers,
+        activeUsers,
+        proUsers: all.proUsers,
+        basicUsers: all.basicUsers,
+      }),
+      { status: 200, headers: { "Content-Type": "application/json" } },
+    );
   }),
 });
 

--- a/convex/lib/adminCommands.ts
+++ b/convex/lib/adminCommands.ts
@@ -61,15 +61,23 @@ export async function handleAdminCommand(
     case "stats": {
       const stats = (await ctx.runQuery(internal.admin.getStats, {})) as {
         totalUsers: number;
+        proUsers: number;
+        basicUsers: number;
+        // Rolling windows: from (now - X) to now
         activeToday: number;
         activeWeek: number;
         activeMonth: number;
-        newToday: number;
-        activeTodayDubai: number;
+        newToday: number; // rolling 24h — different from newTodayDubai (calendar day)
+        newWeek: number;
+        newMonth: number;
+        // Yesterday window: from (now - 48h) to (now - 24h)
+        activeYesterday: number;
+        newYesterday: number;
+        // Dubai calendar-day stats: anchored to Dubai midnight/week-start/month-start (UTC+4)
+        activeTodayDubai: number; // since Dubai midnight — different from activeToday (rolling 24h)
         activeWeekDubai: number;
         activeMonthDubai: number;
-        newTodayDubai: number;
-        proUsers: number;
+        newTodayDubai: number; // since Dubai midnight — different from newToday (rolling 24h)
       };
       return {
         response: await renderSystemMessage(

--- a/convex/templates.ts
+++ b/convex/templates.ts
@@ -315,6 +315,12 @@ New: {{newTodayDubai}} | Active: {{activeTodayDubai}}
 *Last 24 Hours (rolling)*
 New: {{newToday}} | Active: {{activeToday}}
 
+*Last 7 Days (rolling)*
+Active: {{activeWeek}}
+
+*Last 30 Days (rolling)*
+Active: {{activeMonth}}
+
 *This Week (Dubai, starts Sun)*
 Active: {{activeWeekDubai}}
 
@@ -328,6 +334,8 @@ Total: {{totalUsers}} | Pro: {{proUsers}}`,
       "activeTodayDubai",
       "newToday",
       "activeToday",
+      "activeWeek",
+      "activeMonth",
       "activeWeekDubai",
       "activeMonthDubai",
       "totalUsers",


### PR DESCRIPTION
Fixes #117

- Add rolling 7d/30d active counts to admin_stats WhatsApp template
- Consolidate getDashboardStats into getStats: single DB scan serves both WhatsApp command and HTTP endpoint
- Add comments clarifying rolling vs Dubai calendar-day windows

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added pro and basic user breakdowns to admin statistics
  * Added 7-day and 30-day rolling active user metrics
  * Added weekly and monthly new user tracking
  * Added yesterday's activity metrics to dashboard

* **Refactor**
  * Consolidated admin statistics calculation into unified endpoint

<!-- end of auto-generated comment: release notes by coderabbit.ai -->