### PR TITLE
feat(analytics): backfill existing users to PostHog

### DIFF
--- a/convex/analytics.ts
+++ b/convex/analytics.ts
@@ -2,6 +2,7 @@
 
 import { v } from "convex/values";
 import { internalAction } from "./_generated/server";
+import { internal } from "./_generated/api";
 import { PostHog } from "posthog-node";
 import { detectCountryFromPhone } from "./lib/analytics";
 
@@ -397,5 +398,71 @@ export const trackScheduledTaskCreditNotification = internalAction({
       tier,
       phone_country: detectCountryFromPhone(phone),
     });
+  },
+});
+
+// ---------------------------------------------------------------------------
+// One-time backfill: sync all existing users to PostHog
+// ---------------------------------------------------------------------------
+
+const BACKFILL_BATCH_SIZE = 10;
+
+/**
+ * Backfill all existing Convex users into PostHog.
+ * For each user, sends an `identify` call (person profile) and a `user_new` event.
+ * Flushes every BACKFILL_BATCH_SIZE users to avoid action timeout.
+ *
+ * Run once from the Convex dashboard after deployment.
+ */
+export const backfillUsersToPostHog = internalAction({
+  args: {},
+  handler: async (ctx) => {
+    const posthog = getPostHogClient();
+    if (!posthog) {
+      console.warn("[Backfill] PostHog client unavailable — aborting");
+      return { backfilledCount: 0 };
+    }
+
+    const users = await ctx.runQuery(internal.migrations.getAllUsers);
+    let backfilledCount = 0;
+
+    for (const user of users) {
+      const phone = user.phone;
+      const country = detectCountryFromPhone(phone);
+
+      posthog.identify({
+        distinctId: phone,
+        properties: {
+          phone,
+          country,
+          tier: user.tier ?? "basic",
+          timezone: user.timezone ?? "UTC",
+          name: user.name,
+        },
+      });
+
+      posthog.capture({
+        distinctId: phone,
+        event: "user_new",
+        properties: {
+          phone_country: country,
+          timezone: user.timezone ?? "UTC",
+          backfill: true,
+        },
+      });
+
+      backfilledCount++;
+
+      if (backfilledCount % BACKFILL_BATCH_SIZE === 0) {
+        await posthog.flush();
+        console.log(`[Backfill] Flushed ${backfilledCount}/${users.length} users`);
+      }
+    }
+
+    // Final flush for remaining users
+    await posthog.flush();
+    console.log(`[Backfill] Complete: ${backfilledCount} users backfilled to PostHog`);
+
+    return { backfilledCount };
   },
 });

--- a/convex/migrations.ts
+++ b/convex/migrations.ts
@@ -146,3 +146,17 @@ export const countPendingReminders = internalQuery({
     };
   },
 });
+
+// ---------------------------------------------------------------------------
+// PostHog Backfill Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Return all users (for use by backfillUsersToPostHog action via ctx.runQuery).
+ */
+export const getAllUsers = internalQuery({
+  args: {},
+  handler: async (ctx) => {
+    return await ctx.db.query("users").collect();
+  },
+});


### PR DESCRIPTION
## Summary
- Adds `getAllUsers` internal query in `convex/migrations.ts` to fetch all users for the backfill action
- Adds `backfillUsersToPostHog` internal action in `convex/analytics.ts` that syncs all existing Convex users into PostHog with `identify` + `user_new` events (batched flushes every 10 users)
- Backfilled events include `backfill: true` property to distinguish from organic signups

## Test plan
- [ ] Deploy to prod via `npx convex deploy`
- [ ] Run `getAllUsers` from prod dashboard to verify user count
- [ ] Run `backfillUsersToPostHog` from prod dashboard
- [ ] Check PostHog person list to confirm all users appear with correct properties

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a new synchronization capability for user data that processes all existing users in batches with automatic periodic flushing. The system includes detailed progress logging during synchronization, comprehensive error handling, per-user property capture including contact information and account details, and a completion summary for operational transparency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->