### PR TITLE
feat(whatsapp): add reply-to-text context for quoted messages

### DIFF
--- a/convex/lib/twilioSend.test.ts
+++ b/convex/lib/twilioSend.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { sendWhatsAppMessage, sendWhatsAppMedia, sendWhatsAppTemplate } from "./twilioSend";
+import { sendWhatsAppMessage, sendWhatsAppMedia, sendWhatsAppTemplate, fetchMessageBody } from "./twilioSend";
 
 const options = {
   accountSid: "AC_test",
@@ -124,5 +124,52 @@ describe("sendWhatsAppTemplate", () => {
     await expect(
       sendWhatsAppTemplate(options, "HXinvalid", { "1": "test" })
     ).rejects.toThrow("Twilio template API error");
+  });
+});
+
+describe("fetchMessageBody", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  const validSid = "SM" + "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4";
+
+  it("fetches message body by SID", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify({ body: "Hello from Ghali!" }), { status: 200 })
+    );
+
+    const result = await fetchMessageBody("AC_test", "test_token", validSid);
+
+    expect(result).toBe("Hello from Ghali!");
+    expect(fetchSpy).toHaveBeenCalledOnce();
+    const [url, init] = fetchSpy.mock.calls[0];
+    expect(url).toContain(`AC_test/Messages/${validSid}.json`);
+    expect(init?.method).toBe("GET");
+  });
+
+  it("returns null when body is missing", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify({}), { status: 200 })
+    );
+
+    const result = await fetchMessageBody("AC_test", "test_token", validSid);
+    expect(result).toBeNull();
+  });
+
+  it("throws on API error", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response("Not Found", { status: 404 })
+    );
+
+    await expect(
+      fetchMessageBody("AC_test", "test_token", validSid)
+    ).rejects.toThrow("Twilio fetch message error");
+  });
+
+  it("throws on invalid SID format", async () => {
+    await expect(
+      fetchMessageBody("AC_test", "test_token", "INVALID_SID")
+    ).rejects.toThrow("Invalid message SID format");
   });
 });

--- a/convex/lib/twilioSend.ts
+++ b/convex/lib/twilioSend.ts
@@ -70,6 +70,36 @@ export async function sendWhatsAppMedia(
 }
 
 /**
+ * Fetch the body of a previously sent/received message by SID.
+ * Used to provide reply-to-text context when a user quotes a text message.
+ */
+export async function fetchMessageBody(
+  accountSid: string,
+  authToken: string,
+  messageSid: string
+): Promise<string | null> {
+  if (!/^SM[0-9a-f]{32}$/i.test(messageSid)) {
+    throw new Error(`Invalid message SID format: ${messageSid}`);
+  }
+
+  const url = `https://api.twilio.com/2010-04-01/Accounts/${accountSid}/Messages/${messageSid}.json`;
+
+  const response = await fetch(url, {
+    method: "GET",
+    headers: {
+      Authorization: "Basic " + btoa(`${accountSid}:${authToken}`),
+    },
+  });
+
+  if (!response.ok) {
+    throw new Error(`Twilio fetch message error (${response.status}): ${await response.text()}`);
+  }
+
+  const data = await response.json();
+  return data.body ?? null;
+}
+
+/**
  * Send a WhatsApp Content Template message (works outside the 24h session window).
  * Uses ContentSid + ContentVariables instead of Body.
  */

--- a/convex/lib/utils.test.ts
+++ b/convex/lib/utils.test.ts
@@ -9,6 +9,7 @@ import {
   fillTemplate,
   splitLongMessage,
   getCurrentDateTime,
+  buildReplyToTextPrompt,
 } from "./utils";
 
 describe("detectTimezone", () => {
@@ -221,5 +222,36 @@ describe("splitLongMessage", () => {
     const chunks = splitLongMessage(text, 4096);
     expect(chunks.length).toBeGreaterThan(1);
     expect(chunks.join("").length).toBe(10000);
+  });
+});
+
+describe("buildReplyToTextPrompt", () => {
+  it("prepends quoted text to user message", () => {
+    const result = buildReplyToTextPrompt("Original message", "What about this?");
+    expect(result).toBe('[Replying to: "Original message"]\nWhat about this?');
+  });
+
+  it("truncates quoted text exceeding max length", () => {
+    const longQuote = "A".repeat(600);
+    const result = buildReplyToTextPrompt(longQuote, "Tell me more");
+    expect(result).toContain("[Replying to: \"" + "A".repeat(500) + "...\"]");
+    expect(result).toContain("\nTell me more");
+  });
+
+  it("does not truncate text at exactly max length", () => {
+    const exactQuote = "B".repeat(500);
+    const result = buildReplyToTextPrompt(exactQuote, "Reply");
+    expect(result).toBe(`[Replying to: "${exactQuote}"]\nReply`);
+    expect(result).not.toContain("...");
+  });
+
+  it("respects custom max length", () => {
+    const result = buildReplyToTextPrompt("Hello World", "Reply", 5);
+    expect(result).toBe('[Replying to: "Hello..."]\nReply');
+  });
+
+  it("handles empty user message", () => {
+    const result = buildReplyToTextPrompt("Original message", "");
+    expect(result).toBe('[Replying to: "Original message"]\n');
   });
 });

--- a/convex/lib/utils.ts
+++ b/convex/lib/utils.ts
@@ -155,6 +155,24 @@ export function getCurrentDateTime(timezone?: string): {
   return { date, time, tz };
 }
 
+const REPLY_QUOTE_MAX_LENGTH = 500;
+
+/**
+ * Build a prompt with reply-to-text context prepended.
+ * Truncates the quoted body to avoid bloating the prompt.
+ */
+export function buildReplyToTextPrompt(
+  quotedBody: string,
+  userMessage: string,
+  maxQuoteLength: number = REPLY_QUOTE_MAX_LENGTH
+): string {
+  const truncated =
+    quotedBody.length > maxQuoteLength
+      ? quotedBody.slice(0, maxQuoteLength) + "..."
+      : quotedBody;
+  return `[Replying to: "${truncated}"]\n${userMessage}`;
+}
+
 export function splitLongMessage(
   text: string,
   maxLength: number = WHATSAPP_MAX_LENGTH

--- a/convex/messages.ts
+++ b/convex/messages.ts
@@ -4,7 +4,7 @@ import { internal } from "./_generated/api";
 import { Id } from "./_generated/dataModel";
 import { ghaliAgent } from "./agent";
 import { MODELS } from "./models";
-import { getCurrentDateTime, fillTemplate, classifyCommand, isSystemCommand, isAdminCommand, isAffirmative } from "./lib/utils";
+import { getCurrentDateTime, fillTemplate, classifyCommand, isSystemCommand, isAdminCommand, isAffirmative, buildReplyToTextPrompt } from "./lib/utils";
 import { buildUserContext } from "./lib/userFiles";
 import { TEMPLATES } from "./templates";
 import { handleSystemCommand, renderSystemMessage, translateMessage } from "./lib/systemCommands";
@@ -552,6 +552,22 @@ export const generateResponse = internalAction({
           mediaUrl = stored.storageUrl;
           mediaContentType = stored.mediaType;
           isReprocessing = true;
+        }
+      }
+
+      // Reply-to-text: if replying to a text message (no media found), fetch the quoted message
+      if (!mediaUrl && !replyStorageId) {
+        try {
+          const quotedBody: string | null = await ctx.runAction(
+            internal.twilio.fetchOriginalMessage,
+            { messageSid: originalRepliedMessageSid }
+          );
+          if (quotedBody) {
+            prompt = buildReplyToTextPrompt(quotedBody, body);
+          }
+        } catch (e) {
+          // Non-critical — if fetch fails, proceed without quoted context
+          console.warn("Failed to fetch replied-to message:", e);
         }
       }
     }

--- a/convex/twilio.ts
+++ b/convex/twilio.ts
@@ -1,16 +1,26 @@
 import { v } from "convex/values";
 import { internalAction } from "./_generated/server";
-import { sendWhatsAppMessage, sendWhatsAppMedia, sendWhatsAppTemplate } from "./lib/twilioSend";
+import { sendWhatsAppMessage, sendWhatsAppMedia, sendWhatsAppTemplate, fetchMessageBody } from "./lib/twilioSend";
 import { TEMPLATE_DEFINITIONS } from "./admin";
 
 const ALLOWED_TEMPLATE_KEYS: Set<string> = new Set(TEMPLATE_DEFINITIONS.map((t) => t.key));
 
-function getTwilioOptions(to: string) {
+function getTwilioCredentials() {
   const accountSid = process.env.TWILIO_ACCOUNT_SID;
   const authToken = process.env.TWILIO_AUTH_TOKEN;
+
+  if (!accountSid || !authToken) {
+    throw new Error("Missing Twilio environment variables");
+  }
+
+  return { accountSid, authToken };
+}
+
+function getTwilioOptions(to: string) {
+  const { accountSid, authToken } = getTwilioCredentials();
   const from = process.env.TWILIO_WHATSAPP_NUMBER;
 
-  if (!accountSid || !authToken || !from) {
+  if (!from) {
     throw new Error("Missing Twilio environment variables");
   }
 
@@ -35,6 +45,16 @@ export const sendMedia = internalAction({
   },
   handler: async (_ctx, { to, caption, mediaUrl }) => {
     await sendWhatsAppMedia(getTwilioOptions(to), caption, mediaUrl);
+  },
+});
+
+export const fetchOriginalMessage = internalAction({
+  args: {
+    messageSid: v.string(),
+  },
+  handler: async (_ctx, { messageSid }) => {
+    const { accountSid, authToken } = getTwilioCredentials();
+    return await fetchMessageBody(accountSid, authToken, messageSid);
   },
 });
 


### PR DESCRIPTION
## Summary

- When a user replies to a **text** message on WhatsApp, the agent now fetches the original message body via Twilio API and prepends it as `[Replying to: "..."]` context, so the agent understands what's being referenced
- Previously, `originalRepliedMessageSid` was only used to look up stored media — text replies were silently ignored
- Quoted text is truncated to 500 chars to avoid prompt bloat
- Also created GitHub issue #125 for the Profile Layer ("Ghali's Brain") design discussion

## Changes

- **`convex/lib/twilioSend.ts`** — Added `fetchMessageBody()` helper (GET `/Messages/{SID}.json`) with SID format validation
- **`convex/twilio.ts`** — Added `fetchOriginalMessage` internal action; extracted `getTwilioCredentials()` to deduplicate env var fetching
- **`convex/lib/utils.ts`** — Added `buildReplyToTextPrompt()` pure function for testability
- **`convex/messages.ts`** — After media lookup fails, fetches quoted text and prepends to prompt (non-blocking on failure)
- **`convex/lib/twilioSend.test.ts`** — 4 new tests (fetch success, missing body, API error, invalid SID)
- **`convex/lib/utils.test.ts`** — 5 new tests (basic, truncation, boundary, custom max, empty message)

## Test plan

- [x] 676 tests pass (`cd convex && npx vitest run`)
- [x] TypeScript type-check passes (`pnpm type-check`)
- [x] ESLint passes (`pnpm lint`)
- [ ] Manual test: reply to a Ghali text message on WhatsApp and verify the agent sees quoted context
- [ ] Manual test: reply to a media message — existing behavior unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Added support for replying to text messages with quoted original message context
* When replying to a text message, the system now retrieves and includes the original message content as context for better conversation flow

<!-- end of auto-generated comment: release notes by coderabbit.ai -->