### PR TITLE
fix(migrations): detect cryptic snake_case keys in profile format migration

### DIFF
--- a/convex/migrations.ts
+++ b/convex/migrations.ts
@@ -393,13 +393,17 @@ export const migrateProfileFormat = internalAction({
         const hasKeyValue = contentLines.some(
           (l: string) => !l.trim().startsWith("- ") && l.includes(":")
         );
+        // Detect cryptic snake_case keys from old upsertProfileEntry (e.g. "- Bs_dates:", "- Experience_summary:")
+        const hasCrypticKeys = contentLines.some(
+          (l: string) => /^- \w+_\w+:/.test(l.trim())
+        );
 
-        if (hasBullets && !hasKeyValue) {
-          skipped++; // Already in bullet format
+        if (hasBullets && !hasKeyValue && !hasCrypticKeys) {
+          skipped++; // Already in clean bullet format
           continue;
         }
 
-        if (!hasKeyValue) {
+        if (!hasKeyValue && !hasCrypticKeys) {
           skipped++;
           continue;
         }


### PR DESCRIPTION
## Summary
- `migrateProfileFormat` was skipping profiles with cryptic snake_case keys (e.g. `- Bs_dates:`, `- Experience_summary:`) because they already had `- ` bullet prefixes
- Added `hasCrypticKeys` check using regex `/^- \w+_\w+:/` to detect old machine-generated keys that need conversion

## Test plan
- [x] All 701 tests pass
- [x] Build clean
- [ ] Re-run `migrateProfileFormat` via Convex dashboard
- [ ] Verify profile now has human-readable keys

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved profile data migration to detect and process legacy profile formats that were previously skipped. Profiles containing older-style data structures are now properly identified and converted, ensuring more comprehensive data handling during the migration process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->