### PR TITLE
fix(analytics): add $ai_trace_id to PostHog LLM analytics events

### DIFF
--- a/convex/agent.ts
+++ b/convex/agent.ts
@@ -36,6 +36,22 @@ import {
 import { formatProWriteResult, isOpusOverloaded } from "./lib/proWrite";
 import type { AggregateMode, QueryItem } from "./lib/items";
 
+// ---------------------------------------------------------------------------
+// Per-request trace ID for PostHog LLM analytics ($ai_trace_id).
+// Convex actions run in isolation (one invocation at a time), so a module-level
+// variable is safe — no concurrency issues.  The caller sets this before
+// ghaliAgent.generateText() and the usageHandler reads it.
+// ---------------------------------------------------------------------------
+let _currentTraceId: string | undefined;
+
+export function setTraceId(id: string) {
+  _currentTraceId = id;
+}
+
+export function clearTraceId() {
+  _currentTraceId = undefined;
+}
+
 export const SYSTEM_BLOCK = `- Be helpful, honest, and concise. No filler words ("Great question!", "I'd be happy to help!").
 - Never generate harmful, illegal, or abusive content. Refuse politely.
 - Privacy-first: never share one user's data, conversations, or documents with another.
@@ -367,6 +383,7 @@ Rules:
           promptTokens: result.usage?.inputTokens ?? 0,
           completionTokens: result.usage?.outputTokens ?? 0,
           tier: user.tier,
+          traceId: _currentTraceId,
         });
       }
 
@@ -459,6 +476,7 @@ const generateImage = createTool({
         userId: ctx.userId as Id<"users">,
         prompt,
         aspectRatio,
+        traceId: _currentTraceId,
       });
       if (result.success && result.imageUrl) {
         const caption = result.description || "Here's your generated image.";
@@ -1583,6 +1601,7 @@ const proWriteBrief = createTool({
         userId,
         phone: user?.phone,
         tier: user?.tier,
+        traceId: _currentTraceId,
       });
       return JSON.stringify({
         status: "success",
@@ -1639,6 +1658,7 @@ const proWriteExecute = createTool({
         skipClarify: skipClarify ?? false,
         phone: user?.phone,
         tier: user?.tier,
+        traceId: _currentTraceId,
       });
 
       return formatProWriteResult(result);
@@ -1733,6 +1753,7 @@ export const ghaliAgent = new Agent(components.agent, {
         reasoningTokens: reasoningTokens || undefined,
         cachedInputTokens: cachedInputTokens || undefined,
         tier: user.tier,
+        traceId: _currentTraceId,
       });
     } catch (error) {
       console.error("[Analytics] usageHandler failed:", error);

--- a/convex/analytics.ts
+++ b/convex/analytics.ts
@@ -140,9 +140,11 @@ export const trackAIGeneration = internalAction({
     reasoningTokens: v.optional(v.number()),
     cachedInputTokens: v.optional(v.number()),
     tier: v.string(),
+    traceId: v.optional(v.string()),
   },
   handler: async (_ctx, args) => {
     await captureEvent(args.phone, "$ai_generation", {
+      $ai_trace_id: args.traceId,
       $ai_model: args.model,
       $ai_provider: args.provider,
       $ai_input_tokens: args.promptTokens,
@@ -209,8 +211,9 @@ export const trackImageGenerated = internalAction({
     latency_ms: v.optional(v.number()),
     model: v.optional(v.string()),
     tier: v.optional(v.string()),
+    traceId: v.optional(v.string()),
   },
-  handler: async (_ctx, { phone, success, latency_ms, model, tier }) => {
+  handler: async (_ctx, { phone, success, latency_ms, model, tier, traceId }) => {
     const country = detectCountryFromPhone(phone);
 
     // Business event
@@ -222,6 +225,7 @@ export const trackImageGenerated = internalAction({
 
     // LLM Analytics event (shows in PostHog LLM Analytics dashboard)
     await captureEvent(phone, "$ai_generation", {
+      $ai_trace_id: traceId,
       $ai_model: model ?? "gemini-3-pro-image-preview",
       $ai_provider: "google",
       $ai_latency: latency_ms ? latency_ms / 1000 : undefined,

--- a/convex/analyticsHelper.ts
+++ b/convex/analyticsHelper.ts
@@ -17,6 +17,7 @@ export const scheduleTrackAIGeneration = internalMutation({
     reasoningTokens: v.optional(v.number()),
     cachedInputTokens: v.optional(v.number()),
     tier: v.string(),
+    traceId: v.optional(v.string()),
   },
   handler: async (ctx, args) => {
     await ctx.scheduler.runAfter(0, internal.analytics.trackAIGeneration, args);

--- a/convex/heartbeat.ts
+++ b/convex/heartbeat.ts
@@ -1,7 +1,7 @@
 import { v } from "convex/values";
 import { internalMutation, internalAction } from "./_generated/server";
 import { internal } from "./_generated/api";
-import { ghaliAgent, SYSTEM_BLOCK } from "./agent";
+import { ghaliAgent, SYSTEM_BLOCK, setTraceId, clearTraceId } from "./agent";
 import { getCurrentDateTime } from "./lib/utils";
 import { buildUserContext } from "./lib/userFiles";
 import { WHATSAPP_SESSION_WINDOW_MS } from "./constants";
@@ -95,6 +95,9 @@ ${SYSTEM_BLOCK}
 - Keep it concise and actionable
 - After sending a one-shot reminder (not recurring), call updateHeartbeat to remove it from the list. Keep all recurring items.`;
 
+    // Set per-request trace ID for PostHog LLM analytics
+    setTraceId(crypto.randomUUID());
+
     // AI call — circuit breaker scope (only AI errors count)
     let responseText: string | undefined;
     try {
@@ -105,6 +108,8 @@ ${SYSTEM_BLOCK}
       console.error(`Heartbeat AI failed for user ${userId}:`, error);
       await ctx.runMutation(internal.users.recordApiError, { userId });
       return;
+    } finally {
+      clearTraceId();
     }
 
     // Delivery — Twilio failures don't trip the circuit breaker

--- a/convex/images.ts
+++ b/convex/images.ts
@@ -18,10 +18,11 @@ export const generateAndStoreImage = internalAction({
     aspectRatio: v.optional(
       v.union(v.literal("9:16"), v.literal("16:9"), v.literal("1:1"))
     ),
+    traceId: v.optional(v.string()),
   },
   handler: async (
     ctx,
-    { userId, prompt, aspectRatio = "9:16" }
+    { userId, prompt, aspectRatio = "9:16", traceId }
   ): Promise<{
     success: boolean;
     imageUrl?: string;
@@ -80,6 +81,7 @@ export const generateAndStoreImage = internalAction({
             latency_ms: Date.now() - startMs,
             model: MODELS.IMAGE_GENERATION,
             tier: user.tier,
+            traceId,
           });
         }
         return {
@@ -122,6 +124,7 @@ export const generateAndStoreImage = internalAction({
           latency_ms: Date.now() - startMs,
           model: MODELS.IMAGE_GENERATION,
           tier: user.tier,
+          traceId,
         });
         await ctx.scheduler.runAfter(0, internal.analytics.trackFeatureUsed, {
           phone: user.phone,
@@ -140,6 +143,7 @@ export const generateAndStoreImage = internalAction({
           latency_ms: Date.now() - startMs,
           model: MODELS.IMAGE_GENERATION,
           tier: user.tier,
+          traceId,
         });
       }
       return {

--- a/convex/messages.ts
+++ b/convex/messages.ts
@@ -2,7 +2,7 @@ import { v } from "convex/values";
 import { internalMutation, internalAction } from "./_generated/server";
 import { internal } from "./_generated/api";
 import { Id } from "./_generated/dataModel";
-import { ghaliAgent } from "./agent";
+import { ghaliAgent, setTraceId, clearTraceId } from "./agent";
 import { MODELS } from "./models";
 import { getCurrentDateTime, fillTemplate, classifyCommand, isSystemCommand, isAdminCommand, isAffirmative, buildReplyToTextPrompt } from "./lib/utils";
 import { buildUserContext } from "./lib/userFiles";
@@ -664,6 +664,9 @@ export const generateResponse = internalAction({
       userId,
     });
 
+    // Set per-request trace ID for PostHog LLM analytics
+    setTraceId(crypto.randomUUID());
+
     // Generate response
     let responseText: string | undefined;
     let imageResult: { imageUrl: string; caption: string } | null = null;
@@ -717,6 +720,8 @@ export const generateResponse = internalAction({
         // Silent failure — short-circuit to avoid unnecessary work downstream
         return;
       }
+    } finally {
+      clearTraceId();
     }
 
     // Only deduct credit after successful AI response

--- a/convex/proWrite.ts
+++ b/convex/proWrite.ts
@@ -172,12 +172,13 @@ export const generateBrief = internalAction({
     userId: v.id("users"),
     phone: v.optional(v.string()),
     tier: v.optional(v.string()),
+    traceId: v.optional(v.string()),
   },
   returns: v.object({
     brief: v.string(),
     questions: v.array(v.string()),
   }),
-  handler: async (ctx, { request, userId, phone, tier }): Promise<{ brief: string; questions: string[] }> => {
+  handler: async (ctx, { request, userId, phone, tier, traceId }): Promise<{ brief: string; questions: string[] }> => {
     const prompt = buildBriefPrompt(request);
 
     const result = await opusWithFlashFallback("BRIEF", {
@@ -195,6 +196,7 @@ export const generateBrief = internalAction({
           promptTokens: result.promptTokens,
           completionTokens: result.completionTokens,
           tier,
+          traceId,
         });
       } catch (error) {
         console.error("[ProWrite] Failed to schedule BRIEF analytics:", error);
@@ -271,9 +273,10 @@ export const executePipeline = internalAction({
     skipClarify: v.optional(v.boolean()),
     phone: v.optional(v.string()),
     tier: v.optional(v.string()),
+    traceId: v.optional(v.string()),
   },
   returns: v.string(),
-  handler: async (ctx, { answers, userId, personality, skipClarify, phone, tier }) => {
+  handler: async (ctx, { answers, userId, personality, skipClarify, phone, tier, traceId }) => {
     const pipelineStart = Date.now();
     const deadlineMs = pipelineStart + PIPELINE_BUDGET_MS;
 
@@ -288,6 +291,7 @@ export const executePipeline = internalAction({
           promptTokens: result.promptTokens,
           completionTokens: result.completionTokens,
           tier,
+          traceId,
         });
       } catch (error) {
         console.error("[ProWrite] Failed to schedule step analytics:", error);

--- a/convex/scheduledTasks.ts
+++ b/convex/scheduledTasks.ts
@@ -15,7 +15,7 @@ import {
 import { getNextCronRun } from "./lib/cronParser";
 import { getCurrentDateTime } from "./lib/utils";
 import { buildUserContext } from "./lib/userFiles";
-import { ghaliAgent } from "./agent";
+import { ghaliAgent, setTraceId, clearTraceId } from "./agent";
 
 /**
  * Pure helper: determine if a failure notification should be sent.
@@ -299,6 +299,9 @@ export const executeScheduledTask = internalAction({
     // Build prompt (personality/memory language preferences are in userContext)
     const fullPrompt = buildScheduledTaskPrompt(task, userContext);
 
+    // Set per-request trace ID for PostHog LLM analytics
+    setTraceId(crypto.randomUUID());
+
     // Run agent
     let responseText: string | undefined;
     let aiSucceeded = false;
@@ -319,6 +322,8 @@ export const executeScheduledTask = internalAction({
         taskId,
         lastStatus: "error",
       });
+    } finally {
+      clearTraceId();
     }
 
     if (!aiSucceeded || !responseText) {


### PR DESCRIPTION
## Summary

- The PostHog LLM Analytics dashboard had three insights showing "no matching events": **Traces**, **Generative AI users**, and **Cost per user (USD)**
- Root cause: `$ai_generation` events were missing the `$ai_trace_id` property required by PostHog to group events into traces
- Added per-request UUID trace ID generation at all entry points (user messages, heartbeat, scheduled tasks) and propagated it through all analytics pathways: `usageHandler`, `deepReasoning` tool, `generateImage` tool, and ProWrite pipeline

## Test plan

- [x] Typecheck passes (`npx convex typecheck`)
- [x] All 701 tests pass (`pnpm test`)
- [x] Production build succeeds (`pnpm build`)
- [ ] After deploy, verify Traces/Generative AI users/Cost per user insights populate in PostHog LLM Analytics dashboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**Chores**
* Added request tracing for AI operations across image generation, content writing, and search features to improve analytics collection and debugging capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->