### PR TITLE
fix: deduplicate ghali_chat_started Google Ads conversion event

### DIFF
--- a/app/components/landing/cta-button.tsx
+++ b/app/components/landing/cta-button.tsx
@@ -2,6 +2,7 @@
 
 import { usePostHog } from "posthog-js/react";
 import { useCallback } from "react";
+import { trackGhaliChatStarted } from "@/lib/analytics";
 
 interface CtaButtonProps {
   href: string;
@@ -27,6 +28,7 @@ export function CtaButton({ href, location, children, className }: CtaButtonProp
       cta_location: location,
       cta_href: href,
     });
+    trackGhaliChatStarted({ location, href });
   }, [posthog, location, href]);
 
   return (

--- a/app/components/landing/sticky-whatsapp-cta.tsx
+++ b/app/components/landing/sticky-whatsapp-cta.tsx
@@ -3,6 +3,7 @@
 import { usePostHog } from "posthog-js/react";
 import { useCallback } from "react";
 import type { TranslationDict } from "@/app/lib/i18n/types";
+import { trackGhaliChatStarted } from "@/lib/analytics";
 
 export function StickyWhatsAppCta({ t }: { t: TranslationDict }) {
   const posthog = usePostHog();
@@ -17,6 +18,7 @@ export function StickyWhatsAppCta({ t }: { t: TranslationDict }) {
       cta_location: "sticky_whatsapp",
       cta_href: t.whatsappUrl,
     });
+    trackGhaliChatStarted({ location: "sticky_whatsapp", href: t.whatsappUrl });
   }, [posthog, t.whatsappUrl]);
 
   return (

--- a/lib/analytics.ts
+++ b/lib/analytics.ts
@@ -1,0 +1,28 @@
+import posthog from "posthog-js";
+
+declare global {
+  interface Window {
+    gtag?: (...args: unknown[]) => void;
+  }
+}
+
+interface ChatStartedProps {
+  location: string;
+  href: string;
+}
+
+/**
+ * Fires the `ghali_chat_started` conversion event once per device.
+ * Subsequent calls are no-ops to prevent overcounting in Google Ads.
+ */
+export function trackGhaliChatStarted(props: ChatStartedProps): void {
+  if (typeof window === "undefined") return;
+  if (localStorage.getItem("ghali_conv_fired")) return;
+  localStorage.setItem("ghali_conv_fired", "1");
+
+  posthog.capture("ghali_chat_started", { ...props });
+
+  if (window.gtag) {
+    window.gtag("event", "ghali_chat_started", { ...props });
+  }
+}


### PR DESCRIPTION
Closes #147

Add localStorage guard to `trackGhaliChatStarted` so the `ghali_chat_started` conversion event fires only once per device, preventing overcounting in Google Ads.

## Changes
- New `lib/analytics.ts` with `trackGhaliChatStarted` utility
- `cta-button.tsx` calls `trackGhaliChatStarted` on click
- `sticky-whatsapp-cta.tsx` calls `trackGhaliChatStarted` on click

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added analytics tracking for chat initiation events to better measure user engagement.
  * Implemented device-level deduplication to ensure events are counted accurately without duplicates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->