### PR TITLE
fix: replace dynamic import in migration + add scheduled tasks counter

### DIFF
--- a/convex/migrations.ts
+++ b/convex/migrations.ts
@@ -8,6 +8,7 @@ import { generateText } from "ai";
 import { MODELS } from "./constants";
 import { parseProfileSections, replaceProfileSection, type ProfileCategory } from "./lib/profile";
 import { isFileTooLarge } from "./lib/userFiles";
+import { resolveCityToTimezone, buildDefaultPersonality } from "./lib/onboarding";
 
 /** Shared mapping from display section names to ProfileCategory keys. */
 const SECTION_TO_CATEGORY: Record<string, ProfileCategory> = {
@@ -650,7 +651,6 @@ export function extractCityFromProfile(profileContent: string): string | null {
 export const migrateLanguageAndTimezoneBatch = internalMutation({
   args: { userIds: v.array(v.id("users")) },
   handler: async (ctx, { userIds }) => {
-    const { resolveCityToTimezone, buildDefaultPersonality } = await import("./lib/onboarding");
     const DEFAULT_PERSONALITY = buildDefaultPersonality();
     let langUpdated = 0, tzUpdated = 0, personalityReset = 0;
 
@@ -747,6 +747,21 @@ export const migrateLanguageAndTimezone = internalAction({
     }
 
     return `Migration complete: personality reset=${totalPersonality}, language updated=${totalLang}, timezone updated=${totalTz}, total users=${totalProcessed}`;
+  },
+});
+
+/** One-off query: count scheduled tasks and unique users. Run from dashboard. */
+export const countScheduledTasks = internalQuery({
+  args: {},
+  handler: async (ctx) => {
+    const tasks = await ctx.db.query("scheduledTasks").collect();
+    const total = tasks.length;
+    const enabled = tasks.filter(t => t.enabled).length;
+    const disabled = total - enabled;
+    const cron = tasks.filter(t => t.schedule.kind === "cron").length;
+    const once = total - cron;
+    const uniqueUsers = new Set(tasks.map(t => t.userId)).size;
+    return { total, enabled, disabled, cron, once, uniqueUsers };
   },
 });
 


### PR DESCRIPTION
## Summary
- **Fix migration crash**: replace `await import("./lib/onboarding")` with static import in `migrateLanguageAndTimezoneBatch` — Convex mutations don't support dynamic module imports, causing `TypeError: dynamic module import unsupported`
- **Add `countScheduledTasks`**: one-off `internalQuery` to count total/enabled/disabled/cron/once scheduled tasks and unique users — run from Convex dashboard

## Test plan
- [ ] Deploy to prod
- [ ] Run `migrations:countScheduledTasks` from dashboard — verify it returns stats
- [ ] Run `migrations:migrateLanguageAndTimezone` from dashboard — verify no dynamic import error

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved task scheduling statistics collection for better internal monitoring and performance insights.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->