### PR TITLE
fix: outbound rate guard, single-response guarantee, webhook hardening

### DIFF
--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -50,6 +50,7 @@ import type * as memoryCompaction from "../memoryCompaction.js";
 import type * as messages from "../messages.js";
 import type * as migrations from "../migrations.js";
 import type * as models from "../models.js";
+import type * as outboundGuard from "../outboundGuard.js";
 import type * as proWrite from "../proWrite.js";
 import type * as rag from "../rag.js";
 import type * as rateLimiting from "../rateLimiting.js";
@@ -110,6 +111,7 @@ declare const fullApi: ApiFromModules<{
   messages: typeof messages;
   migrations: typeof migrations;
   models: typeof models;
+  outboundGuard: typeof outboundGuard;
   proWrite: typeof proWrite;
   rag: typeof rag;
   rateLimiting: typeof rateLimiting;

--- a/convex/constants.ts
+++ b/convex/constants.ts
@@ -212,6 +212,12 @@ export const MAX_MESSAGE_LENGTH = 10_000;
 /** TTL for processed webhook dedup entries (24 hours) */
 export const WEBHOOK_DEDUP_TTL_MS = 24 * 60 * 60 * 1000;
 
+/** Minimum interval between outbound messages to the same user (ms) */
+export const OUTBOUND_MIN_INTERVAL_MS = 2_000;
+
+/** Maximum outbound messages to the same user per minute */
+export const OUTBOUND_MAX_PER_MINUTE = 10;
+
 /** Number of consecutive AI API errors before the circuit breaker trips */
 export const ERROR_CIRCUIT_BREAKER_THRESHOLD = 3;
 

--- a/convex/http.ts
+++ b/convex/http.ts
@@ -36,99 +36,102 @@ http.route({
   path: "/whatsapp-webhook",
   method: "POST",
   handler: httpAction(async (ctx, request) => {
-    // Parse form data
-    const formData = await request.formData();
-    const params: Record<string, string> = {};
-    formData.forEach((value, key) => {
-      params[key] = value.toString();
-    });
-
-    // Validate Twilio signature
-    const authToken = process.env.TWILIO_AUTH_TOKEN;
-    const signature = request.headers.get("X-Twilio-Signature") ?? "";
-
-    if (!authToken) {
-      console.error("TWILIO_AUTH_TOKEN not set");
-      return new Response("Server error", { status: 500 });
-    }
-
-    const url = new URL(request.url);
-    // Use the public-facing URL for signature validation
-    const publicUrl =
-      process.env.CONVEX_SITE_URL ??
-      `${url.protocol}//${url.host}`;
-    const validationUrl = `${publicUrl}/whatsapp-webhook`;
-
-    if (!(await validateTwilioSignature(authToken, signature, validationUrl, params))) {
-      return new Response("Forbidden", { status: 403 });
-    }
-
-    // Parse the message
-    const message = parseTwilioMessage(params);
-
-    // Ignore messages from Ghali's own number — outbound delivery echoes or status
-    // callbacks would otherwise re-trigger the agent pipeline and cause feedback loops.
-    const ghaliNumber = normalizeWhatsappNumber(process.env.TWILIO_WHATSAPP_NUMBER);
-    if (!ghaliNumber && !warnedMissingTwilioWhatsappNumber) {
-      warnedMissingTwilioWhatsappNumber = true;
-      console.warn("TWILIO_WHATSAPP_NUMBER not set — self-message filter disabled");
-    }
-    if (ghaliNumber && normalizeWhatsappNumber(message.from) === ghaliNumber) {
-      return new Response("<Response></Response>", {
+    // ALWAYS return 200 to Twilio — non-200 causes retries which can amplify bugs.
+    // The only exception is 403 for bad signatures (Twilio doesn't retry 4xx).
+    const twimlOk = () =>
+      new Response("<Response></Response>", {
         status: 200,
         headers: { "Content-Type": "text/xml" },
       });
-    }
 
-    // Country code blocking
-    if (isBlockedCountryCode(message.from)) {
-      console.log(`Blocked message from ${message.from}`);
-      return new Response("<Response></Response>", {
-      status: 200,
-      headers: { "Content-Type": "text/xml" },
-    });
-    }
-
-    // Truncate overly long messages (cost amplification protection)
-    if (message.body.length > MAX_MESSAGE_LENGTH) {
-      message.body = message.body.slice(0, MAX_MESSAGE_LENGTH);
-    }
-
-    // MessageSid dedup — reject replayed webhooks (atomic check-and-mark)
-    if (message.messageSid) {
-      const isNew = await ctx.runMutation(internal.webhookDedup.tryMarkProcessed, {
-        messageSid: message.messageSid,
+    try {
+      // Parse form data
+      const formData = await request.formData();
+      const params: Record<string, string> = {};
+      formData.forEach((value, key) => {
+        params[key] = value.toString();
       });
-      if (!isNew) {
-        console.log(`Duplicate MessageSid ${message.messageSid}, skipping`);
-        return new Response("<Response></Response>", {
-          status: 200,
-          headers: { "Content-Type": "text/xml" },
-        });
+
+      // Validate Twilio signature
+      const authToken = process.env.TWILIO_AUTH_TOKEN;
+      const signature = request.headers.get("X-Twilio-Signature") ?? "";
+
+      if (!authToken) {
+        console.error("TWILIO_AUTH_TOKEN not set");
+        // Return 200 even on config errors — returning 500 causes Twilio retries
+        return twimlOk();
       }
+
+      const url = new URL(request.url);
+      // Use the public-facing URL for signature validation
+      const publicUrl =
+        process.env.CONVEX_SITE_URL ??
+        `${url.protocol}//${url.host}`;
+      const validationUrl = `${publicUrl}/whatsapp-webhook`;
+
+      if (!(await validateTwilioSignature(authToken, signature, validationUrl, params))) {
+        // 403 is fine — Twilio does NOT retry 4xx responses
+        return new Response("Forbidden", { status: 403 });
+      }
+
+      // Parse the message
+      const message = parseTwilioMessage(params);
+
+      // Ignore messages from Ghali's own number — outbound delivery echoes or status
+      // callbacks would otherwise re-trigger the agent pipeline and cause feedback loops.
+      const ghaliNumber = normalizeWhatsappNumber(process.env.TWILIO_WHATSAPP_NUMBER);
+      if (!ghaliNumber && !warnedMissingTwilioWhatsappNumber) {
+        warnedMissingTwilioWhatsappNumber = true;
+        console.warn("TWILIO_WHATSAPP_NUMBER not set — self-message filter disabled");
+      }
+      if (ghaliNumber && normalizeWhatsappNumber(message.from) === ghaliNumber) {
+        return twimlOk();
+      }
+
+      // Country code blocking
+      if (isBlockedCountryCode(message.from)) {
+        console.log(`Blocked message from ${message.from}`);
+        return twimlOk();
+      }
+
+      // Truncate overly long messages (cost amplification protection)
+      if (message.body.length > MAX_MESSAGE_LENGTH) {
+        message.body = message.body.slice(0, MAX_MESSAGE_LENGTH);
+      }
+
+      // MessageSid dedup — reject replayed webhooks (atomic check-and-mark)
+      if (message.messageSid) {
+        const isNew = await ctx.runMutation(internal.webhookDedup.tryMarkProcessed, {
+          messageSid: message.messageSid,
+        });
+        if (!isNew) {
+          console.log(`Duplicate MessageSid ${message.messageSid}, skipping`);
+          return twimlOk();
+        }
+      }
+
+      // Find or create user + schedule async processing
+      const userId = await ctx.runMutation(internal.users.findOrCreateUser, {
+        phone: message.from,
+        name: message.profileName,
+      });
+
+      // Schedule async message processing
+      await ctx.runMutation(internal.messages.saveIncoming, {
+        userId,
+        body: message.body,
+        mediaUrl: message.mediaUrl,
+        mediaContentType: message.mediaContentType,
+        messageSid: message.messageSid,
+        originalRepliedMessageSid: message.originalRepliedMessageSid,
+      });
+
+      return twimlOk();
+    } catch (error) {
+      // Catch-all: log the error but ALWAYS return 200 to prevent Twilio retries
+      console.error("[whatsapp-webhook] Unhandled error:", error);
+      return twimlOk();
     }
-
-    // Find or create user + schedule async processing
-    const userId = await ctx.runMutation(internal.users.findOrCreateUser, {
-      phone: message.from,
-      name: message.profileName,
-    });
-
-    // Schedule async message processing
-    await ctx.runMutation(internal.messages.saveIncoming, {
-      userId,
-      body: message.body,
-      mediaUrl: message.mediaUrl,
-      mediaContentType: message.mediaContentType,
-      messageSid: message.messageSid,
-      originalRepliedMessageSid: message.originalRepliedMessageSid,
-    });
-
-    // Return 200 immediately
-    return new Response("<Response></Response>", {
-      status: 200,
-      headers: { "Content-Type": "text/xml" },
-    });
   }),
 });
 

--- a/convex/messages.ts
+++ b/convex/messages.ts
@@ -167,8 +167,94 @@ export const generateResponse = internalAction({
     let { body, mediaUrl, mediaContentType } = args;
     const typedUserId = userId as Id<"users">;
 
+    // ── Single response guarantee ──────────────────────────────────────
+    // Ensures at most ONE outbound message (or message group) per invocation.
+    // Every send path must go through guardedSend() instead of calling
+    // internal.twilio.sendMessage / sendMedia directly.
+    let responseSent = false;
+
+    /**
+     * Send a text message to the user, guarded against double-sends.
+     * Returns true if sent, false if blocked (already sent this invocation).
+     */
+    async function guardedSendMessage(msgBody: string): Promise<boolean> {
+      if (responseSent) {
+        console.warn(
+          `[single-response-guard] Blocked duplicate send to ${userId} ` +
+            `(messageSid: ${messageSid})`
+        );
+        return false;
+      }
+      // Outbound rate guard — check DB-backed per-user rate limit
+      const guard = await ctx.runMutation(
+        internal.outboundGuard.checkAndRecordOutbound,
+        { userId: typedUserId }
+      );
+      if (!guard.allowed) {
+        console.warn(
+          `[outbound-guard] Blocked send to ${userId}: ${guard.reason}`
+        );
+        return false;
+      }
+      responseSent = true;
+      await ctx.runAction(internal.twilio.sendMessage, {
+        to: user!.phone,
+        body: msgBody,
+      });
+      return true;
+    }
+
+    /**
+     * Send a media message to the user, guarded against double-sends.
+     * Falls back to text-only on Twilio error.
+     */
+    async function guardedSendMedia(
+      caption: string,
+      mediaUrlToSend: string
+    ): Promise<boolean> {
+      if (responseSent) {
+        console.warn(
+          `[single-response-guard] Blocked duplicate media send to ${userId}`
+        );
+        return false;
+      }
+      const guard = await ctx.runMutation(
+        internal.outboundGuard.checkAndRecordOutbound,
+        { userId: typedUserId }
+      );
+      if (!guard.allowed) {
+        console.warn(
+          `[outbound-guard] Blocked media send to ${userId}: ${guard.reason}`
+        );
+        return false;
+      }
+      responseSent = true;
+      try {
+        await ctx.runAction(internal.twilio.sendMedia, {
+          to: user!.phone,
+          caption,
+          mediaUrl: mediaUrlToSend,
+        });
+      } catch (error) {
+        console.error(
+          `[guardedSendMedia] sendMedia failed for ${userId}, falling back to text. ` +
+            `Note: if original was partially sent, user may receive duplicate.`,
+          error
+        );
+        await ctx.runAction(internal.twilio.sendMessage, {
+          to: user!.phone,
+          body: caption,
+        });
+      }
+      return true;
+    }
+
+    // `user` is set below after the initial query — referenced by guard helpers.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    let user: any = null;
+
     // Get user info
-    const user = await ctx.runQuery(internal.users.internalGetUser, {
+    user = await ctx.runQuery(internal.users.internalGetUser, {
       userId: typedUserId,
     });
 
@@ -284,10 +370,7 @@ export const generateResponse = internalAction({
         if (sentInfographic) {
           await new Promise((r) => setTimeout(r, 2000));
         }
-        await ctx.runAction(internal.twilio.sendMessage, {
-          to: user.phone,
-          body: translatedResponse,
-        });
+        await guardedSendMessage(translatedResponse);
         return;
       }
       // Fall through to AI with onboarding already marked done (nextStep: null)
@@ -327,10 +410,7 @@ export const generateResponse = internalAction({
             { sentCount: result.sentCount },
             body
           );
-          await ctx.runAction(internal.twilio.sendMessage, {
-            to: user.phone,
-            body: doneMessage,
-          });
+          await guardedSendMessage(doneMessage);
           return;
         }
 
@@ -374,10 +454,7 @@ export const generateResponse = internalAction({
             doneVars,
             body
           );
-          await ctx.runAction(internal.twilio.sendMessage, {
-            to: user.phone,
-            body: doneMessage,
-          });
+          await guardedSendMessage(doneMessage);
           return;
         }
 
@@ -387,10 +464,7 @@ export const generateResponse = internalAction({
             userId: typedUserId,
           });
           const farewellMsg = await renderSystemMessage("delete_account_done", {}, body);
-          await ctx.runAction(internal.twilio.sendMessage, {
-            to: user.phone,
-            body: farewellMsg,
-          });
+          await guardedSendMessage(farewellMsg);
           await ctx.runAction(internal.accountControl.deleteAccount, {
             userId: typedUserId,
           });
@@ -448,10 +522,7 @@ export const generateResponse = internalAction({
           phone: user.phone,
           command: messageForCredits,
         });
-        await ctx.runAction(internal.twilio.sendMessage, {
-          to: user.phone,
-          body: systemResult.response,
-        });
+        await guardedSendMessage(systemResult.response);
         return;
       }
       // Unrecognized command → fall through to AI
@@ -473,10 +544,7 @@ export const generateResponse = internalAction({
             payload: adminResult.pendingPayload,
           });
         }
-        await ctx.runAction(internal.twilio.sendMessage, {
-          to: user.phone,
-          body: adminResult.response,
-        });
+        await guardedSendMessage(adminResult.response);
         return;
       }
     }
@@ -501,10 +569,7 @@ export const generateResponse = internalAction({
         tier: user.tier,
         reset_at: user.creditsResetAt,
       });
-      await ctx.runAction(internal.twilio.sendMessage, {
-        to: user.phone,
-        body: message,
-      });
+      await guardedSendMessage(message);
       return;
     }
 
@@ -517,10 +582,7 @@ export const generateResponse = internalAction({
       const message = fillTemplate(TEMPLATES.rate_limited.template, {
         retryAfterSeconds: rateCheck.retryAfterSeconds,
       });
-      await ctx.runAction(internal.twilio.sendMessage, {
-        to: user.phone,
-        body: message,
-      });
+      await guardedSendMessage(message);
       return;
     }
 
@@ -544,10 +606,7 @@ export const generateResponse = internalAction({
       );
 
       if (!voiceResult) {
-        await ctx.runAction(internal.twilio.sendMessage, {
-          to: user.phone,
-          body: TEMPLATES.voice_transcription_failed.template,
-        });
+        await guardedSendMessage(TEMPLATES.voice_transcription_failed.template);
         return;
       }
 
@@ -610,10 +669,7 @@ export const generateResponse = internalAction({
                 ? `${body}\n\n[Voice note transcript: "${voiceResult.transcript}"]`
                 : `[Voice note transcript: "${voiceResult.transcript}"]`;
             } else {
-              await ctx.runAction(internal.twilio.sendMessage, {
-                to: user.phone,
-                body: TEMPLATES.voice_transcription_failed.template,
-              });
+              await guardedSendMessage(TEMPLATES.voice_transcription_failed.template);
               return;
             }
           }
@@ -653,10 +709,7 @@ export const generateResponse = internalAction({
       );
 
       if (!result) {
-        await ctx.runAction(internal.twilio.sendMessage, {
-          to: user.phone,
-          body: TEMPLATES.document_extraction_failed.template,
-        });
+        await guardedSendMessage(TEMPLATES.document_extraction_failed.template);
         return;
       }
 
@@ -812,41 +865,11 @@ export const generateResponse = internalAction({
     }
 
     if (convertedResult) {
-      // Send converted file as WhatsApp media
-      try {
-        await ctx.runAction(internal.twilio.sendMedia, {
-          to: user.phone,
-          caption: convertedResult.caption,
-          mediaUrl: convertedResult.fileUrl,
-        });
-      } catch (error) {
-        console.error("sendMedia (conversion) failed, falling back to text:", error);
-        await ctx.runAction(internal.twilio.sendMessage, {
-          to: user.phone,
-          body: convertedResult.caption,
-        });
-      }
+      await guardedSendMedia(convertedResult.caption, convertedResult.fileUrl);
     } else if (imageResult) {
-      // Image analytics tracked in images.ts (with latency + model detail)
-      // Send generated image as WhatsApp media, fall back to text if media fails
-      try {
-        await ctx.runAction(internal.twilio.sendMedia, {
-          to: user.phone,
-          caption: imageResult.caption,
-          mediaUrl: imageResult.imageUrl,
-        });
-      } catch (error) {
-        console.error("sendMedia failed, falling back to text:", error);
-        await ctx.runAction(internal.twilio.sendMessage, {
-          to: user.phone,
-          body: imageResult.caption,
-        });
-      }
+      await guardedSendMedia(imageResult.caption, imageResult.imageUrl);
     } else if (responseText) {
-      await ctx.runAction(internal.twilio.sendMessage, {
-        to: user.phone,
-        body: responseText,
-      });
+      await guardedSendMessage(responseText);
     }
   },
 });

--- a/convex/outboundGuard.ts
+++ b/convex/outboundGuard.ts
@@ -1,0 +1,57 @@
+import { v } from "convex/values";
+import { internalMutation } from "./_generated/server";
+import { OUTBOUND_MIN_INTERVAL_MS, OUTBOUND_MAX_PER_MINUTE } from "./constants";
+
+/**
+ * Outbound rate guard — prevents sending too many messages to the same user.
+ *
+ * Two checks:
+ * 1. Minimum interval between messages (e.g. 2s)
+ * 2. Maximum messages per minute
+ *
+ * Returns { allowed: true } and records the send, or { allowed: false, reason: string }.
+ */
+export const checkAndRecordOutbound = internalMutation({
+  args: { userId: v.id("users") },
+  handler: async (
+    ctx,
+    { userId }
+  ): Promise<{ allowed: true } | { allowed: false; reason: string }> => {
+    const user = await ctx.db.get(userId);
+    if (!user) return { allowed: false, reason: "user_not_found" };
+
+    const now = Date.now();
+
+    // Check 1: Minimum interval since last outbound
+    if (
+      user.lastOutboundAt &&
+      now - user.lastOutboundAt < OUTBOUND_MIN_INTERVAL_MS
+    ) {
+      return {
+        allowed: false,
+        reason: `outbound_too_fast: ${now - user.lastOutboundAt}ms since last send`,
+      };
+    }
+
+    // Check 2: Max messages per minute
+    const windowStart = user.outboundWindowStart ?? 0;
+    const countInWindow = user.outboundCountInWindow ?? 0;
+    const windowExpired = now - windowStart > 60_000;
+
+    if (!windowExpired && countInWindow >= OUTBOUND_MAX_PER_MINUTE) {
+      return {
+        allowed: false,
+        reason: `outbound_rate_exceeded: ${countInWindow} messages in current minute window`,
+      };
+    }
+
+    // Record this send
+    await ctx.db.patch(userId, {
+      lastOutboundAt: now,
+      outboundCountInWindow: windowExpired ? 1 : countInWindow + 1,
+      outboundWindowStart: windowExpired ? now : windowStart,
+    });
+
+    return { allowed: true };
+  },
+});

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -27,6 +27,12 @@ export default defineSchema({
     pendingActionAt: v.optional(v.number()),
     pendingPayload: v.optional(v.string()),
     lastMessageAt: v.optional(v.number()),
+    /** Timestamp of last outbound message — used for outbound rate guard */
+    lastOutboundAt: v.optional(v.number()),
+    /** Number of outbound messages in the current minute window */
+    outboundCountInWindow: v.optional(v.number()),
+    /** Start of the current outbound rate window (epoch ms) */
+    outboundWindowStart: v.optional(v.number()),
     consecutiveErrors: v.optional(v.number()),
     errorBackoffUntil: v.optional(v.number()),
     personalityBootstrapped: v.optional(v.boolean()),


### PR DESCRIPTION
## Summary
- **Webhook always returns 200** — wrapped entire handler in try/catch; missing `TWILIO_AUTH_TOKEN` now returns 200 instead of 500 (which caused Twilio retries)
- **Outbound rate guard** — new DB-backed per-user check (`outboundGuard.ts`): 2s min interval between messages + 10 messages/minute max per recipient
- **Single response guarantee** — `responseSent` flag + `guardedSendMessage`/`guardedSendMedia` helpers replace all 12 direct send call sites in `generateResponse`, preventing duplicate outbound messages per invocation

## Context
100 messages sent to one user in 63 seconds caused WhatsApp error 63018 (rate limit exceeded) and account ban. These three layers of defense-in-depth prevent any similar incident regardless of root cause.

## Test plan
- [x] All 715 existing tests pass
- [x] TypeScript typecheck clean
- [x] Convex codegen succeeds
- [x] CodeRabbit review: 1 minor finding (observability improvement) — addressed
- [ ] Deploy to dev and verify: send image → single response, no duplicates
- [ ] Verify outbound guard logs appear when rate exceeded (test with rapid manual messages)
- [ ] Verify webhook returns 200 on simulated errors (check Twilio debugger for retries)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Implemented outbound message rate limiting to manage message delivery volume (maximum 10 messages per minute per user; minimum 2-second interval between messages).

* **Improvements**
  * Enhanced webhook error handling to reduce unnecessary message retries and strengthened message signature validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->