### PR TITLE
fix: cap message chunks to 3 — root cause of 100-message flood

### DIFF
--- a/convex/constants.ts
+++ b/convex/constants.ts
@@ -65,6 +65,14 @@ export const WHATSAPP_MAX_LENGTH = 1500;
 /** Delay between multi-part Twilio messages (ms) to preserve ordering */
 export const TWILIO_MESSAGE_DELAY_MS = 500;
 
+/**
+ * Maximum number of WhatsApp message chunks per outbound send.
+ * Prevents runaway splitting from flooding a recipient.
+ * 3 chunks × 1500 chars = 4500 chars — plenty for any reasonable response.
+ * Anything beyond this is truncated with a "message too long" footer.
+ */
+export const MAX_MESSAGE_CHUNKS = 3;
+
 // ============================================================================
 // Voice Notes
 // ============================================================================

--- a/convex/lib/twilioSend.ts
+++ b/convex/lib/twilioSend.ts
@@ -3,7 +3,7 @@
  * Used as a Convex action since it needs HTTP access.
  */
 import { splitLongMessage } from "./utils";
-import { TWILIO_MESSAGE_DELAY_MS } from "../constants";
+import { TWILIO_MESSAGE_DELAY_MS, MAX_MESSAGE_CHUNKS } from "../constants";
 import { formatForWhatsApp } from "./formatter";
 
 interface TwilioSendOptions {
@@ -52,6 +52,15 @@ export async function sendWhatsAppMessage(
 ): Promise<void> {
   const formatted = formatForWhatsApp(body);
   const chunks = splitLongMessage(formatted);
+
+  // Defense-in-depth: hard cap on chunks even if splitLongMessage is misconfigured
+  if (chunks.length > MAX_MESSAGE_CHUNKS) {
+    console.error(
+      `[twilioSend] CRITICAL: ${chunks.length} chunks exceed MAX_MESSAGE_CHUNKS (${MAX_MESSAGE_CHUNKS}). ` +
+        `Truncating to prevent message flood. Original length: ${body.length} chars`
+    );
+    chunks.length = MAX_MESSAGE_CHUNKS;
+  }
 
   for (let i = 0; i < chunks.length; i++) {
     if (i > 0) {

--- a/convex/lib/utils.test.ts
+++ b/convex/lib/utils.test.ts
@@ -219,9 +219,23 @@ describe("splitLongMessage", () => {
 
   it("splits long messages into multiple chunks", () => {
     const text = "A".repeat(10000);
-    const chunks = splitLongMessage(text, 4096);
+    const chunks = splitLongMessage(text, 4096, 10);
     expect(chunks.length).toBeGreaterThan(1);
     expect(chunks.join("").length).toBe(10000);
+  });
+
+  it("caps chunks at maxChunks and truncates", () => {
+    // 150,000 chars with 1500 max = 100 chunks without cap
+    const text = "A".repeat(150_000);
+    const chunks = splitLongMessage(text, 1500, 3);
+    expect(chunks.length).toBe(3);
+    expect(chunks[2]).toContain("_(Message truncated — too long)_");
+  });
+
+  it("respects default maxChunks of 3", () => {
+    const text = "A".repeat(10000);
+    const chunks = splitLongMessage(text, 1500);
+    expect(chunks.length).toBeLessThanOrEqual(3);
   });
 });
 

--- a/convex/lib/utils.ts
+++ b/convex/lib/utils.ts
@@ -4,6 +4,7 @@
 
 import {
   WHATSAPP_MAX_LENGTH,
+  MAX_MESSAGE_CHUNKS,
   COUNTRY_CODE_TIMEZONES,
   DEFAULT_TIMEZONE,
   BLOCKED_COUNTRY_CODES,
@@ -175,7 +176,8 @@ export function buildReplyToTextPrompt(
 
 export function splitLongMessage(
   text: string,
-  maxLength: number = WHATSAPP_MAX_LENGTH
+  maxLength: number = WHATSAPP_MAX_LENGTH,
+  maxChunks: number = MAX_MESSAGE_CHUNKS
 ): string[] {
   if (text.length <= maxLength) {
     return [text];
@@ -184,7 +186,7 @@ export function splitLongMessage(
   const chunks: string[] = [];
   let remaining = text;
 
-  while (remaining.length > maxLength) {
+  while (remaining.length > maxLength && chunks.length < maxChunks - 1) {
     // Try to split at paragraph boundary
     let splitIndex = remaining.lastIndexOf("\n\n", maxLength);
 
@@ -209,7 +211,17 @@ export function splitLongMessage(
   }
 
   if (remaining.length > 0) {
-    chunks.push(remaining);
+    // If we hit the chunk limit and there's still more text, truncate with notice
+    if (chunks.length >= maxChunks - 1 && remaining.length > maxLength) {
+      const truncated = remaining.slice(0, maxLength - 40);
+      chunks.push(truncated.trim() + "\n\n_(Message truncated — too long)_");
+      console.warn(
+        `[splitLongMessage] Truncated: ${text.length} chars → ${chunks.length} chunks ` +
+          `(${remaining.length - maxLength + 40} chars dropped)`
+      );
+    } else {
+      chunks.push(remaining);
+    }
   }
 
   return chunks;


### PR DESCRIPTION
## Summary
- **Root cause identified**: Twilio logs show ~0.58s interval between all 100 messages = `TWILIO_MESSAGE_DELAY_MS` (500ms) + API latency. A single `sendWhatsAppMessage` call split a massive AI response into ~100 chunks via `splitLongMessage` (no chunk cap), then sent them sequentially.
- **Fix**: Add `MAX_MESSAGE_CHUNKS = 3` hard cap. Messages beyond 4500 chars are truncated with a `_(Message truncated — too long)_` footer.
- **Defense-in-depth**: `sendWhatsAppMessage` also has a hard cap on the loop, independent of `splitLongMessage`.

## Root cause analysis
```
100 outbound messages × ~0.58s interval = 58s total
0.58s = TWILIO_MESSAGE_DELAY_MS (500ms) + Twilio API latency (~80ms)
100 chunks × 1500 chars/chunk = ~150,000 character AI response
```
This was NOT a webhook retry, dedup, or loop issue. PR #169's protections (dedup, outbound guard, responseSent flag) are still valuable defense-in-depth but didn't address this specific failure mode.

## Test plan
- [x] All 716 tests pass (2 new tests for chunk capping)
- [x] TypeScript typecheck clean
- [ ] Deploy to dev, send a large document, verify response is max 3 messages
- [ ] Verify truncation notice appears on long responses

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Implemented a 3-chunk message limit for WhatsApp sends to prevent message overflow
  * Messages exceeding the limit are automatically truncated with a "message too long" footer notification
  * Added runtime safeguards to enforce the message chunk limit

<!-- end of auto-generated comment: release notes by coderabbit.ai -->