### PR TITLE
fix: add missing /v1/media/ path in 360dialog media download URL

### DIFF
--- a/convex/lib/whatsappSend.ts
+++ b/convex/lib/whatsappSend.ts
@@ -148,7 +148,7 @@ export async function downloadMedia(
   try {
     // Step 1: Get media URL
     const metaResponse = await fetch(
-      `${DIALOG360_BASE_URL}/${mediaId}`,
+      `${DIALOG360_BASE_URL}/v1/media/${mediaId}`,
       {
         headers: { "D360-API-KEY": apiKey },
       }


### PR DESCRIPTION
Fixes media messages (images, voice notes, documents) failing with "Sorry, I couldn't process that file" because the media metadata fetch URL was missing the required `/v1/media/` path segment in the 360dialog API call.

Closes #178

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated WhatsApp media retrieval process to use the latest API endpoint format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->