### PR TITLE
fix: revert 360dialog media URL to correct v2 format

### DIFF
--- a/convex/lib/whatsappSend.ts
+++ b/convex/lib/whatsappSend.ts
@@ -148,7 +148,7 @@ export async function downloadMedia(
   try {
     // Step 1: Get media URL
     const metaResponse = await fetch(
-      `${DIALOG360_BASE_URL}/v1/media/${mediaId}`,
+      `${DIALOG360_BASE_URL}/${mediaId}`,
       {
         headers: { "D360-API-KEY": apiKey },
       }


### PR DESCRIPTION
Remove incorrect /v1/media/ path prefix introduced by #178/#180.

The correct v2 endpoint is `GET ${DIALOG360_BASE_URL}/${mediaId}`.

Closes #182

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced media handling for WhatsApp sending functionality by updating the media metadata retrieval process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->