### PR TITLE
feat: typing indicator via 360dialog Cloud API

### DIFF
--- a/convex/http.ts
+++ b/convex/http.ts
@@ -134,6 +134,14 @@ http.route({
           }
         }
 
+        // Fire typing indicator immediately (non-blocking)
+        // Shows read receipt (blue ticks) + three-dot typing animation for up to 25s
+        if (message.messageId) {
+          ctx.scheduler.runAfter(0, internal.whatsapp.sendTypingIndicator, {
+            messageId: message.messageId,
+          });
+        }
+
         // Find or create user + schedule async processing
         const userId = await ctx.runMutation(internal.users.findOrCreateUser, {
           phone: message.from,

--- a/convex/lib/whatsapp.test.ts
+++ b/convex/lib/whatsapp.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from "vitest";
 import {
   validateWebhookSignature,
   parseCloudApiWebhook,
+  buildTypingIndicatorPayload,
 } from "./whatsapp";
 import { createHmac } from "crypto";
 
@@ -302,5 +303,33 @@ describe("parseCloudApiWebhook", () => {
 
     const messages = parseCloudApiWebhook(payload);
     expect(messages).toHaveLength(0);
+  });
+});
+
+describe("buildTypingIndicatorPayload", () => {
+  it("produces correct payload shape for a given message ID", () => {
+    const payload = buildTypingIndicatorPayload("wamid.abc123");
+    expect(payload).toEqual({
+      messaging_product: "whatsapp",
+      status: "read",
+      message_id: "wamid.abc123",
+      typing_indicator: { type: "text" },
+    });
+  });
+
+  it("includes the exact message ID provided", () => {
+    const messageId = "wamid.HBgM971501234567VjIyBAAGHiQA1234";
+    const payload = buildTypingIndicatorPayload(messageId);
+    expect(payload.message_id).toBe(messageId);
+  });
+
+  it("always sets status to read", () => {
+    const payload = buildTypingIndicatorPayload("wamid.test");
+    expect(payload.status).toBe("read");
+  });
+
+  it("always sets typing_indicator type to text", () => {
+    const payload = buildTypingIndicatorPayload("wamid.test");
+    expect((payload.typing_indicator as { type: string }).type).toBe("text");
   });
 });

--- a/convex/lib/whatsapp.ts
+++ b/convex/lib/whatsapp.ts
@@ -151,6 +151,24 @@ export function parseCloudApiWebhook(
 }
 
 // ============================================================================
+// Typing Indicator
+// ============================================================================
+
+/**
+ * Build the payload for the 360dialog typing indicator API call.
+ * Marks the incoming message as read (blue ticks) and shows typing dots
+ * for up to 25 seconds or until Ghali replies.
+ */
+export function buildTypingIndicatorPayload(messageId: string): Record<string, unknown> {
+  return {
+    messaging_product: "whatsapp",
+    status: "read",
+    message_id: messageId,
+    typing_indicator: { type: "text" },
+  };
+}
+
+// ============================================================================
 // Cloud API Webhook Payload Types
 // ============================================================================
 

--- a/convex/whatsapp.ts
+++ b/convex/whatsapp.ts
@@ -2,6 +2,7 @@ import { v } from "convex/values";
 import { internalAction } from "./_generated/server";
 import { internal } from "./_generated/api";
 import { sendWhatsAppMessage, sendWhatsAppMedia, sendWhatsAppTemplate, downloadMedia } from "./lib/whatsappSend";
+import { buildTypingIndicatorPayload } from "./lib/whatsapp";
 import { TEMPLATE_DEFINITIONS } from "./admin";
 
 const ALLOWED_TEMPLATE_NAMES: Set<string> = new Set(TEMPLATE_DEFINITIONS.map((t) => t.name));
@@ -136,5 +137,31 @@ export const guardedSendTemplate = internalAction({
       return;
     }
     await sendWhatsAppTemplate(getSendOptions(to), templateName, variables);
+  },
+});
+
+/**
+ * Send a typing indicator to the user immediately after receiving their message.
+ * Marks the incoming message as read (blue double-ticks) and shows the
+ * three-dot typing animation for up to 25 seconds or until Ghali replies.
+ * Errors are swallowed silently — a failed indicator must never block processing.
+ */
+export const sendTypingIndicator = internalAction({
+  args: { messageId: v.string() },
+  handler: async (_ctx, { messageId }) => {
+    try {
+      const apiKey = process.env.DIALOG360_API_KEY!;
+      const baseUrl = process.env.DIALOG360_API_URL ?? "https://waba-v2.360dialog.io";
+      await fetch(`${baseUrl}/messages`, {
+        method: "POST",
+        headers: {
+          "D360-API-KEY": apiKey,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify(buildTypingIndicatorPayload(messageId)),
+      });
+    } catch (err) {
+      console.warn("[typing-indicator] Failed to send typing indicator:", err);
+    }
   },
 });


### PR DESCRIPTION
Show read receipt (blue double-ticks) and three-dot typing animation while Ghali processes a message.

- Add `buildTypingIndicatorPayload()` pure helper to `convex/lib/whatsapp.ts`
- Add `sendTypingIndicator` internal action to `convex/whatsapp.ts`
- Fire non-blocking via `scheduler.runAfter(0, ...)` in `convex/http.ts`
- Add 4 tests for payload shape in `convex/lib/whatsapp.test.ts`

Closes #185

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic typing indicators for WhatsApp conversations that display when the app processes incoming messages, providing visual feedback to senders that their message is being handled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->