### PR TITLE
fix: proxy 360dialog media downloads to avoid 401

### DIFF
--- a/convex/lib/whatsappSend.test.ts
+++ b/convex/lib/whatsappSend.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { sendWhatsAppMessage, sendWhatsAppMedia, sendWhatsAppTemplate } from "./whatsappSend";
+import { sendWhatsAppMessage, sendWhatsAppMedia, sendWhatsAppTemplate, rewriteToProxy } from "./whatsappSend";
 
 const options = {
   apiKey: "test_api_key_123",
@@ -129,5 +129,33 @@ describe("sendWhatsAppTemplate", () => {
     await expect(
       sendWhatsAppTemplate(options, "ghali_reminder", { "1": "test" })
     ).rejects.toThrow("360dialog API error");
+  });
+});
+
+describe("rewriteToProxy", () => {
+  const baseUrl = "https://waba-v2.360dialog.io";
+
+  it("rewrites Facebook CDN URL to 360dialog proxy", () => {
+    const fbUrl = "https://lookaside.fbsbx.com/whatsapp_business/attachments/?mid=123&ext=456&hash=abc";
+    const result = rewriteToProxy(fbUrl, baseUrl);
+    expect(result).toContain("waba-v2.360dialog.io");
+    expect(result).toContain("mid=123");
+    expect(result).toContain("ext=456");
+    expect(result).not.toContain("lookaside.fbsbx.com");
+  });
+
+  it("preserves URL that already matches base hostname", () => {
+    const url = "https://waba-v2.360dialog.io/some/path?q=1";
+    expect(rewriteToProxy(url, baseUrl)).toBe(url);
+  });
+
+  it("returns original URL for invalid input", () => {
+    expect(rewriteToProxy("not-a-url", baseUrl)).toBe("not-a-url");
+  });
+
+  it("rewrites protocol and clears port", () => {
+    const url = "http://cdn.example.com:8080/path";
+    const result = rewriteToProxy(url, baseUrl);
+    expect(result).toBe("https://waba-v2.360dialog.io/path");
   });
 });

--- a/convex/lib/whatsappSend.ts
+++ b/convex/lib/whatsappSend.ts
@@ -170,26 +170,8 @@ export async function downloadMedia(
       return null;
     }
 
-    // Step 2: Download binary data
-    // The metadata URL is a Facebook CDN URL (lookaside.fbsbx.com) which
-    // doesn't accept D360-API-KEY. Replace the host with 360dialog's proxy
-    // so the request goes through their API with our key.
-    let proxyUrl = downloadUrl;
-    try {
-      const base = new URL(DIALOG360_BASE_URL);
-      const parsed = new URL(downloadUrl);
-      if (parsed.hostname !== base.hostname) {
-        parsed.hostname = base.hostname;
-        parsed.protocol = base.protocol;
-        parsed.port = "";
-        proxyUrl = parsed.toString();
-      }
-    } catch (e) {
-      // If URL parsing fails, use the original URL as-is
-      console.warn("[whatsappSend] Could not parse download URL, using as-is:", downloadUrl, e);
-    }
-
-    const dataResponse = await fetch(proxyUrl, {
+    // Step 2: Download binary data via 360dialog proxy
+    const dataResponse = await fetch(rewriteToProxy(downloadUrl, DIALOG360_BASE_URL), {
       headers: { "D360-API-KEY": apiKey },
     });
 
@@ -205,5 +187,29 @@ export async function downloadMedia(
   } catch (error) {
     console.error(`[whatsappSend] Media download error for ${mediaId}:`, error);
     return null;
+  }
+}
+
+/**
+ * Rewrite a media download URL to go through 360dialog's proxy.
+ *
+ * The 360dialog Cloud API metadata endpoint returns a Facebook CDN URL
+ * (lookaside.fbsbx.com) which doesn't accept the D360-API-KEY header.
+ * Replacing the host routes the request through 360dialog's proxy instead.
+ * Falls back to the original URL if parsing fails.
+ */
+export function rewriteToProxy(downloadUrl: string, baseUrl: string): string {
+  try {
+    const base = new URL(baseUrl);
+    const parsed = new URL(downloadUrl);
+    if (parsed.hostname !== base.hostname) {
+      parsed.hostname = base.hostname;
+      parsed.protocol = base.protocol;
+      parsed.port = "";
+      return parsed.toString();
+    }
+    return downloadUrl;
+  } catch {
+    return downloadUrl;
   }
 }


### PR DESCRIPTION
## Summary
- 360dialog's media metadata endpoint returns a Facebook CDN URL (`lookaside.fbsbx.com`) that rejects the `D360-API-KEY` header with 401
- Extract `rewriteToProxy()` pure function that rewrites the hostname to route downloads through 360dialog's proxy (`waba-v2.360dialog.io`)
- Add unit tests for the URL rewriting logic (Facebook CDN, same-host no-op, invalid URL fallback, protocol/port rewrite)

## Test plan
- [x] Unit tests for `rewriteToProxy()` (4 cases)
- [x] Tested on prod: image sent via WhatsApp → downloaded and processed successfully
- [x] All 747 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Implemented proxy-based URL routing for WhatsApp media downloads, enabling intelligent traffic routing with fallback handling for various URL formats and edge cases.

* **Tests**
  * Added comprehensive test coverage for URL proxy routing logic, validating protocol handling, hostname matching, and error tolerance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->