### PR TITLE
fix: prevent silent reply drops and inline reflection leaks

### DIFF
--- a/convex/messages.test.ts
+++ b/convex/messages.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from "vitest";
 import {
   extractResponseText,
+  stripInlineReflection,
   REFLECTION_TOOL_NAMES,
   parseImageToolResult,
   extractImageFromSteps,
@@ -119,10 +120,145 @@ describe("extractResponseText", () => {
     expect(extractResponseText(steps)).toBe("Here is the full answer!");
   });
 
+  it("does not suppress reply when real tool preceded reflection-only step (addItem → appendToMemory → reply)", () => {
+    // Step 0: addItem (real tool, no text)
+    // Step 1: appendToMemory only (reflection, no text)
+    // Step 2: reply text (no tool calls) — should NOT be suppressed
+    const steps = [
+      step("", ["addItem"]),
+      step("", ["appendToMemory"]),
+      step("I've added your Apple TV subscription — 250 AED."),
+    ];
+    expect(extractResponseText(steps)).toBe(
+      "I've added your Apple TV subscription — 250 AED."
+    );
+  });
+
+  it("does not suppress reply when real tool + reflection in same step preceded reflection-only step", () => {
+    // Step 0: addItem + updateProfile (mixed, no text)
+    // Step 1: appendToMemory only (reflection, no text)
+    // Step 2: reply text — should NOT be suppressed
+    const steps = [
+      step("", ["addItem", "updateProfile"]),
+      step("", ["appendToMemory"]),
+      step("Done! Expense tracked."),
+    ];
+    expect(extractResponseText(steps)).toBe("Done! Expense tracked.");
+  });
+
+  it("still suppresses reflection when no real tool was called in any earlier step", () => {
+    // Step 0: appendToMemory only (reflection, with response text)
+    // Step 1: updateProfile only (reflection, no text)
+    // Step 2: reflection text (should be suppressed)
+    const steps = [
+      step("Good morning!", ["appendToMemory"]),
+      step("", ["updateProfile"]),
+      step("Reflecting on Hesham's morning greeting pattern."),
+    ];
+    expect(extractResponseText(steps)).toBe("Good morning!");
+  });
+
   it("handles a single step with only reflection tools and text (edge case: should return the text since i=0)", () => {
     // Only one step, can't be a reflection leak (no preceding step to check)
     const steps = [step("Some text.", ["appendToMemory"])];
     expect(extractResponseText(steps)).toBe("Some text.");
+  });
+
+  it("strips inline reflection from response text", () => {
+    const steps = [
+      step(
+        "Here are your cars!\n\n• BMW X5\n• Nissan Patrol\n\n**Reflecting on behavioral patterns...**\n• The user tracks cars",
+        ["addItem"]
+      ),
+    ];
+    expect(extractResponseText(steps)).toBe(
+      "Here are your cars!\n\n• BMW X5\n• Nissan Patrol"
+    );
+  });
+});
+
+describe("stripInlineReflection", () => {
+  it("returns text unchanged when no reflection is present", () => {
+    expect(stripInlineReflection("Hello! How are you?")).toBe(
+      "Hello! How are you?"
+    );
+  });
+
+  it("strips 'Reflecting on' block", () => {
+    const text =
+      "I've added your expense!\n\n**Reflecting on behavioral patterns...**\n• Noticed the user tracks expenses";
+    expect(stripInlineReflection(text)).toBe("I've added your expense!");
+  });
+
+  it("strips 'Silent reflection' block", () => {
+    const text =
+      "Here are your cars!\n\n**Silent reflection: Identity and memory updates...**\n• Profile: No new milestones.";
+    expect(stripInlineReflection(text)).toBe("Here are your cars!");
+  });
+
+  it("strips at the earliest matching pattern", () => {
+    const text =
+      "Your list is ready.\n\n**Reflecting on behavioral patterns...**\n• bullet\n\n**Silent reflection: Identity and memory updates...**\n• more";
+    expect(stripInlineReflection(text)).toBe("Your list is ready.");
+  });
+
+  it("handles patterns without bold markers", () => {
+    const text =
+      "Done!\n\nReflecting on the user's preferences...\n• prefers bullet points";
+    expect(stripInlineReflection(text)).toBe("Done!");
+  });
+
+  it("handles Memory update pattern (with newline after colon)", () => {
+    const text = "All set!\n\nMemory update:\n• Added preference for dark mode";
+    expect(stripInlineReflection(text)).toBe("All set!");
+  });
+
+  it("does NOT strip Memory update in a legitimate reply (no newline after colon)", () => {
+    const text =
+      "Here's what changed:\n\nMemory update: your preference for dark mode was saved.";
+    expect(stripInlineReflection(text)).toBe(text);
+  });
+
+  it("handles Profile update pattern (with newline after colon)", () => {
+    const text = "Done!\n\nProfile update:\n• Updated job title";
+    expect(stripInlineReflection(text)).toBe("Done!");
+  });
+
+  it("does NOT strip Profile update in a legitimate reply (no newline after colon)", () => {
+    const text = "Sure thing!\n\nProfile update: your name has been changed.";
+    expect(stripInlineReflection(text)).toBe(text);
+  });
+
+  it("handles Behavioral pattern header", () => {
+    const text =
+      "Here you go!\n\nBehavioral pattern observations:\n• User prefers short answers";
+    expect(stripInlineReflection(text)).toBe("Here you go!");
+  });
+
+  it("handles Internal note pattern", () => {
+    const text = "Here you go!\n\nInternal note: user likes concise replies";
+    expect(stripInlineReflection(text)).toBe("Here you go!");
+  });
+
+  it("returns empty string unchanged", () => {
+    expect(stripInlineReflection("")).toBe("");
+  });
+
+  it("returns text with reflection at the very start after newline", () => {
+    // Edge case: reflection is the entire text (preceded by newline)
+    const text = "\nReflecting on the user's message...";
+    expect(stripInlineReflection(text)).toBe("");
+  });
+
+  it("does not strip when reflection appears without leading newline", () => {
+    // First line — no \n prefix — should NOT be matched
+    const text = "Reflecting on your question, here's what I think...";
+    expect(stripInlineReflection(text)).toBe(text);
+  });
+
+  it("handles indented reflection with leading whitespace", () => {
+    const text = "Your answer:\n   **Reflecting on behavioral patterns...**\n• stuff";
+    expect(stripInlineReflection(text)).toBe("Your answer:");
   });
 });
 

--- a/convex/messages.ts
+++ b/convex/messages.ts
@@ -128,6 +128,48 @@ export const REFLECTION_TOOL_NAMES = new Set([
 ]);
 
 /**
+ * Patterns that indicate the start of an inline reflection block.
+ * The LLM sometimes embeds internal narration directly in the response text
+ * instead of emitting it in a separate step. These patterns match the known
+ * headers the model uses, and everything from the first match to the end of
+ * the text is stripped.
+ */
+const INLINE_REFLECTION_PATTERNS: RegExp[] = [
+  /\n\s*\*{0,2}Reflecting on\b/i,
+  /\n\s*\*{0,2}Silent reflection\b/i,
+  /\n\s*\*{0,2}Identity and memory update/i,
+  // Require "..." or a newline after the colon to avoid matching legitimate
+  // agent replies like "Memory update: your preference was saved".
+  /\n\s*\*{0,2}Memory update\s*[:—]\s*\n/i,
+  /\n\s*\*{0,2}Profile update\s*[:—]\s*\n/i,
+  /\n\s*\*{0,2}Behavioral pattern/i,
+  /\n\s*\*{0,2}Internal note/i,
+];
+
+/**
+ * Strip inline reflection blocks from a response text.
+ *
+ * Sometimes the LLM ignores the "SILENT REFLECTION" instruction and embeds
+ * internal narration (e.g. "**Reflecting on behavioral patterns...**")
+ * directly within the user-facing reply. This function finds the earliest
+ * such block and removes everything from that point onward.
+ */
+export function stripInlineReflection(text: string): string {
+  if (!text) return text;
+
+  let earliest = -1;
+  for (const pattern of INLINE_REFLECTION_PATTERNS) {
+    const match = pattern.exec(text);
+    if (match && (earliest === -1 || match.index < earliest)) {
+      earliest = match.index;
+    }
+  }
+
+  if (earliest === -1) return text;
+  return text.slice(0, earliest).trimEnd();
+}
+
+/**
  * Extract the user-facing response text from agent generation steps.
  *
  * After generating a response the agent calls memory/profile update tools
@@ -140,14 +182,26 @@ export const REFLECTION_TOOL_NAMES = new Set([
  * A step's text is suppressed when ALL of the following are true:
  *   1. The step has no tool calls (it is a terminating text-only step).
  *   2. The immediately preceding step called ONLY reflection tools.
+ *   3. A user-facing response was already captured from an earlier step.
+ *
+ * Condition 3 prevents false suppression when the agent does real work
+ * (e.g. addItem) in an earlier step, then reflects, then emits the reply
+ * as the first text — since no prior text was captured, it must be the
+ * actual response, not a reflection leak.
  *
  * This covers the two common reflection-leak patterns:
  *   Pattern A — main response + reflection tool in step 0, reflection text in step 1.
  *   Pattern C — web search (step 0) → response + reflection tool (step 1) → reflection text (step 2).
  *
+ * But correctly preserves the reply in patterns like:
+ *   addItem (step 0) → appendToMemory (step 1) → reply text (step 2).
+ *
  * The function also recovers the user-facing text when the model produces an
  * empty final step (no text) after reflection tools, returning the text from
  * the last substantive response step instead.
+ *
+ * As a final safety net, inline reflection blocks are stripped from the
+ * returned text via {@link stripInlineReflection}.
  */
 export function extractResponseText(
   steps: Array<{ text: string; toolCalls: Array<{ toolName: string }> }>
@@ -160,18 +214,21 @@ export function extractResponseText(
 
     // Detect reflection-leak: this step has no tool calls (terminating step)
     // and the previous step called only reflection tools.
+    // But only suppress if we already captured user-facing text earlier —
+    // if lastGoodText is still empty, this must be the actual reply
+    // (e.g. addItem → appendToMemory → reply text).
     if (step.toolCalls.length === 0 && i > 0) {
       const prev = steps[i - 1];
       const prevOnlyReflection =
         prev.toolCalls.length > 0 &&
         prev.toolCalls.every((tc) => REFLECTION_TOOL_NAMES.has(tc.toolName));
-      if (prevOnlyReflection) continue; // suppress reflection text
+      if (prevOnlyReflection && lastGoodText) continue; // suppress reflection text
     }
 
     lastGoodText = step.text;
   }
 
-  return lastGoodText;
+  return stripInlineReflection(lastGoodText);
 }
 
 /**


### PR DESCRIPTION
## Summary
- **Silent reply drops:** `extractResponseText` incorrectly suppressed the actual reply when the agent step pattern was `addItem → appendToMemory → reply text` (the reply was the first text, but the preceding reflection-only step triggered suppression). Fixed by only suppressing when a user-facing response was already captured.
- **Inline reflection leaks:** Added `stripInlineReflection()` to detect and strip internal narration (e.g. "Reflecting on behavioral patterns...", "Silent reflection: Identity and memory updates...") that the LLM sometimes embeds directly in the response text, ignoring the SILENT REFLECTION instruction.

## Test plan
- [x] 38 unit tests for `extractResponseText` and `stripInlineReflection` (16 new)
- [x] All 766 tests pass
- [x] Pre-push hooks pass (typecheck, lint, tests)
- [ ] Manual test: send voice note adding an expense, verify confirmation reply is received
- [ ] Manual test: send a message that triggers memory/profile updates, verify no reflection text in reply

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Removed inline reflection patterns from displayed response text, providing cleaner and more user-focused content.

* **Tests**
  * Added comprehensive test coverage for reflection pattern detection and removal to ensure reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->