### PR TITLE
fix: pass explicit media type for converted file sends

### DIFF
--- a/convex/lib/whatsappSend.test.ts
+++ b/convex/lib/whatsappSend.test.ts
@@ -85,6 +85,40 @@ describe("sendWhatsAppMedia", () => {
     expect(body.image.caption).toBe("Check this image");
     expect(body.image.link).toBe("https://example.com/image.jpg");
   });
+
+  it("uses mediaTypeHint when provided instead of inferring from URL", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify({ messages: [{ id: "wamid.doc1" }] }), { status: 200 })
+    );
+
+    // Convex storage URL has no extension — would default to "image" without hint
+    await sendWhatsAppMedia(
+      options,
+      "Here's your PDF",
+      "https://xxx.convex.cloud/api/storage/abc123",
+      "document"
+    );
+
+    const body = JSON.parse(fetchSpy.mock.calls[0][1]?.body as string);
+    expect(body.type).toBe("document");
+    expect(body.document.caption).toBe("Here's your PDF");
+    expect(body.document.link).toBe("https://xxx.convex.cloud/api/storage/abc123");
+  });
+
+  it("falls back to URL inference when no mediaTypeHint provided", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify({ messages: [{ id: "wamid.pdf1" }] }), { status: 200 })
+    );
+
+    await sendWhatsAppMedia(
+      options,
+      "Here's a PDF",
+      "https://example.com/report.pdf"
+    );
+
+    const body = JSON.parse(fetchSpy.mock.calls[0][1]?.body as string);
+    expect(body.type).toBe("document");
+  });
 });
 
 describe("sendWhatsAppTemplate", () => {

--- a/convex/lib/whatsappSend.ts
+++ b/convex/lib/whatsappSend.ts
@@ -88,10 +88,11 @@ function inferMediaType(mediaUrl: string): "image" | "document" | "audio" | "vid
 export async function sendWhatsAppMedia(
   options: WhatsAppSendOptions,
   caption: string,
-  mediaUrl: string
+  mediaUrl: string,
+  mediaTypeHint?: "image" | "document" | "audio" | "video"
 ): Promise<void> {
   const to = normalizePhoneForApi(options.to);
-  const mediaType = inferMediaType(mediaUrl);
+  const mediaType = mediaTypeHint ?? inferMediaType(mediaUrl);
 
   await cloudApiCall(options.apiKey, {
     recipient_type: "individual",

--- a/convex/messages.test.ts
+++ b/convex/messages.test.ts
@@ -8,6 +8,7 @@ import {
   extractToolResultText,
   parseConvertedFileResult,
   extractConvertedFileFromSteps,
+  convertedFormatToWhatsAppType,
 } from "./messages";
 
 // Helper to build a step for tests
@@ -420,5 +421,29 @@ describe("extractConvertedFileFromSteps", () => {
 
   it("returns null for empty steps", () => {
     expect(extractConvertedFileFromSteps([])).toBeNull();
+  });
+});
+
+describe("convertedFormatToWhatsAppType", () => {
+  it("maps document formats to 'document'", () => {
+    expect(convertedFormatToWhatsAppType("pdf")).toBe("document");
+    expect(convertedFormatToWhatsAppType("docx")).toBe("document");
+    expect(convertedFormatToWhatsAppType("csv")).toBe("document");
+  });
+
+  it("maps image formats to 'image'", () => {
+    expect(convertedFormatToWhatsAppType("png")).toBe("image");
+    expect(convertedFormatToWhatsAppType("jpg")).toBe("image");
+    expect(convertedFormatToWhatsAppType("webp")).toBe("image");
+  });
+
+  it("maps audio formats to 'audio'", () => {
+    expect(convertedFormatToWhatsAppType("mp3")).toBe("audio");
+    expect(convertedFormatToWhatsAppType("wav")).toBe("audio");
+    expect(convertedFormatToWhatsAppType("ogg")).toBe("audio");
+  });
+
+  it("defaults unknown formats to 'document'", () => {
+    expect(convertedFormatToWhatsAppType("xyz")).toBe("document");
   });
 });

--- a/convex/messages.ts
+++ b/convex/messages.ts
@@ -73,6 +73,20 @@ export function parseConvertedFileResult(
 }
 
 /**
+ * Map a convertFile output format to the WhatsApp Cloud API media type.
+ * Convex storage URLs have no file extension, so we can't infer from URL.
+ */
+export function convertedFormatToWhatsAppType(
+  outputFormat: string
+): "image" | "document" | "audio" | "video" {
+  const fmt = outputFormat.toLowerCase();
+  if (["png", "jpg", "jpeg", "webp"].includes(fmt)) return "image";
+  if (["mp3", "wav", "ogg", "aac", "flac"].includes(fmt)) return "audio";
+  if (["mp4", "webm", "3gpp", "mov"].includes(fmt)) return "video";
+  return "document";
+}
+
+/**
  * Extract the string value from a tool result, handling both formats:
  * - Legacy (AI SDK v5 / older @convex-dev/agent): `result` is a plain string
  * - Current (@convex-dev/agent 0.3.x): `output` is `{ type: "text", value: "..." }`
@@ -358,7 +372,8 @@ export const generateResponse = internalAction({
      */
     async function guardedSendMedia(
       caption: string,
-      mediaUrlToSend: string
+      mediaUrlToSend: string,
+      mediaType?: "image" | "document" | "audio" | "video"
     ): Promise<boolean> {
       if (responseSent) {
         console.warn(
@@ -382,6 +397,7 @@ export const generateResponse = internalAction({
           to: user!.phone,
           caption,
           mediaUrl: mediaUrlToSend,
+          mediaType,
         });
       } catch (error) {
         console.error(
@@ -999,9 +1015,10 @@ export const generateResponse = internalAction({
 
     // Send the primary reply first — this is what the user is waiting for
     if (convertedResult) {
-      await guardedSendMedia(convertedResult.caption, convertedResult.fileUrl);
+      const waMediaType = convertedFormatToWhatsAppType(convertedResult.outputFormat);
+      await guardedSendMedia(convertedResult.caption, convertedResult.fileUrl, waMediaType);
     } else if (imageResult) {
-      await guardedSendMedia(imageResult.caption, imageResult.imageUrl);
+      await guardedSendMedia(imageResult.caption, imageResult.imageUrl, "image");
     } else if (responseText) {
       await guardedSendMessage(responseText);
     }

--- a/convex/whatsapp.ts
+++ b/convex/whatsapp.ts
@@ -35,9 +35,15 @@ export const sendMedia = internalAction({
     to: v.string(),
     caption: v.string(),
     mediaUrl: v.string(),
+    mediaType: v.optional(v.union(
+      v.literal("image"),
+      v.literal("document"),
+      v.literal("audio"),
+      v.literal("video"),
+    )),
   },
-  handler: async (_ctx, { to, caption, mediaUrl }) => {
-    await sendWhatsAppMedia(getSendOptions(to), caption, mediaUrl);
+  handler: async (_ctx, { to, caption, mediaUrl, mediaType }) => {
+    await sendWhatsAppMedia(getSendOptions(to), caption, mediaUrl, mediaType);
   },
 });
 


### PR DESCRIPTION
## Summary

- Convex storage URLs have no file extension, so `inferMediaType()` always defaulted to `"image"` — causing WhatsApp to silently drop document/audio/video sends from file conversion
- Added `mediaTypeHint` param through the send chain: `guardedSendMedia` → `sendMedia` action → `sendWhatsAppMedia`
- New `convertedFormatToWhatsAppType()` maps output formats (pdf, docx, png, mp3, etc.) to WhatsApp Cloud API media types
- Image sends now also pass explicit `"image"` type for consistency

## Test plan

- [x] 801 tests pass (6 new)
- [x] `sendWhatsAppMedia` with explicit hint overrides URL inference
- [x] `sendWhatsAppMedia` falls back to URL inference when no hint
- [x] `convertedFormatToWhatsAppType` maps all conversion formats correctly
- [ ] Manual: send DOCX → ask to convert to PDF → should receive PDF file on WhatsApp

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for explicitly specifying media types when sending files via WhatsApp (image, document, audio, or video).
  * Improved automatic media type detection and conversion for various file formats.

* **Tests**
  * Added comprehensive test coverage for media type handling and format conversion scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->