### PR TITLE
fix: show active vs dormant user counts in admin stats

### DIFF
--- a/convex/admin.ts
+++ b/convex/admin.ts
@@ -95,8 +95,8 @@ export const getStats = internalQuery({
 
     const allUsers = await ctx.db.query("users").collect();
 
-    const totalUsers = allUsers.length;
     const dormantUsers = allUsers.filter((u) => u.dormant === true).length;
+    const totalUsers = allUsers.length - dormantUsers;
     const proUsers = allUsers.filter((u) => u.tier === "pro").length;
     const basicUsers = allUsers.filter((u) => u.tier === "basic").length;
 

--- a/convex/lib/adminCommands.ts
+++ b/convex/lib/adminCommands.ts
@@ -61,6 +61,7 @@ export async function handleAdminCommand(
     case "stats": {
       const stats = (await ctx.runQuery(internal.admin.getStats, {})) as {
         totalUsers: number;
+        dormantUsers: number;
         proUsers: number;
         basicUsers: number;
         // Rolling windows: from (now - X) to now
@@ -84,6 +85,7 @@ export async function handleAdminCommand(
           "admin_stats",
           {
             totalUsers: stats.totalUsers,
+            dormantUsers: stats.dormantUsers,
             activeToday: stats.activeToday,
             activeWeek: stats.activeWeek,
             activeMonth: stats.activeMonth,

--- a/convex/templates.ts
+++ b/convex/templates.ts
@@ -287,7 +287,7 @@ Active: {{activeWeekDubai}}
 Active: {{activeMonthDubai}}
 
 *All Time*
-Total: {{totalUsers}} | Pro: {{proUsers}}`,
+Active: {{totalUsers}} | Dormant: {{dormantUsers}} | Pro: {{proUsers}}`,
     variables: [
       "newTodayDubai",
       "activeTodayDubai",
@@ -298,6 +298,7 @@ Total: {{totalUsers}} | Pro: {{proUsers}}`,
       "activeWeekDubai",
       "activeMonthDubai",
       "totalUsers",
+      "dormantUsers",
       "proUsers",
     ],
   },


### PR DESCRIPTION
## Changes

Split the 'Total' user count in `admin stats` into two separate numbers:

- **Active** — users created after the 360dialog migration (non-dormant)
- **Dormant** — pre-360dialog users who should not receive outbound messages

### Before
```
*All Time*
Total: 388 | Pro: 0
```

### After
```
*All Time*
Active: 3 | Dormant: 385 | Pro: 0
```

### Files changed
- `convex/admin.ts` — `totalUsers` now excludes dormant users
- `convex/lib/adminCommands.ts` — added `dormantUsers` to type + render call
- `convex/templates.ts` — updated `All Time` line to show both counts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added dormant user tracking to admin statistics. The admin dashboard now displays active and dormant user counts separately for improved visibility into user engagement metrics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->