### PR TITLE
fix: change 'Active' label to 'Users' in admin stats All Time section

### DIFF
--- a/convex/templates.ts
+++ b/convex/templates.ts
@@ -287,7 +287,7 @@ Active: {{activeWeekDubai}}
 Active: {{activeMonthDubai}}
 
 *All Time*
-Active: {{totalUsers}} | Dormant: {{dormantUsers}} | Pro: {{proUsers}}`,
+Users: {{totalUsers}} | Dormant: {{dormantUsers}} | Pro: {{proUsers}}`,
     variables: [
       "newTodayDubai",
       "activeTodayDubai",


### PR DESCRIPTION
The 'Active' label in the All Time section of `/admin stats` was misleading, as it represents total non-dormant users, not currently active users.

Changes the label from `Active:` to `Users:` in the admin_stats template.

Closes #215

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated a metric label in the admin dashboard for improved clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->