### PR TITLE
fix: use 30-day inactivity gate for credit reset notifications

### DIFF
--- a/convex/constants.ts
+++ b/convex/constants.ts
@@ -168,6 +168,9 @@ export const WHATSAPP_SESSION_WINDOW_MS = 24 * 60 * 60 * 1000;
 /** Template inactivity gate (7 days) — do not send proactive templates to users inactive longer than this */
 export const TEMPLATE_INACTIVITY_GATE_MS = 7 * 24 * 60 * 60 * 1000;
 
+/** Credit reset inactivity gate (30 days) — skip credit reset notifications for users inactive longer than this */
+export const CREDIT_RESET_INACTIVITY_GATE_MS = 30 * 24 * 60 * 60 * 1000;
+
 // ============================================================================
 // Structured Data (Items & Collections)
 // ============================================================================

--- a/convex/credits.ts
+++ b/convex/credits.ts
@@ -7,7 +7,7 @@ import {
   CREDITS_PRO,
   CREDIT_RESET_PERIOD_MS,
   WHATSAPP_SESSION_WINDOW_MS,
-  TEMPLATE_INACTIVITY_GATE_MS,
+  CREDIT_RESET_INACTIVITY_GATE_MS,
 } from "./constants";
 
 /**
@@ -86,8 +86,8 @@ export const resetCredits = internalMutation({
         });
 
         // Notify user — guarded to respect outbound rate limits
-        // Skip notification for inactive users (>7 days since last message)
-        const isInactive = !user.lastMessageAt || now - user.lastMessageAt > TEMPLATE_INACTIVITY_GATE_MS;
+        // Skip notification for inactive users (>30 days since last message)
+        const isInactive = !user.lastMessageAt || now - user.lastMessageAt > CREDIT_RESET_INACTIVITY_GATE_MS;
         if (isInactive) {
           // Reset creditNotificationSent on all user's scheduled tasks
           await ctx.scheduler.runAfter(0, internal.scheduledTasks.resetCreditNotifications, {


### PR DESCRIPTION
## Summary
- Added a dedicated `CREDIT_RESET_INACTIVITY_GATE_MS` constant (30 days) separate from the general `TEMPLATE_INACTIVITY_GATE_MS` (7 days)
- Credit reset notifications now skip users inactive for >30 days instead of >7 days, matching the monthly reset cadence
- Other proactive messages (heartbeat, reminders) still use the 7-day gate

## Test plan
- [ ] Verify typecheck and tests pass in CI
- [ ] Confirm credit reset skips notification for users with `lastMessageAt` > 30 days ago
- [ ] Confirm heartbeat/reminders still use the 7-day inactivity gate

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated credit reset notification logic to skip notifications for users inactive longer than 30 days.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->