### PR TITLE
fix: update ghali_credits_refresh template footer with STOP, DELETE, and HELP options

### DIFF
--- a/scripts/create-templates-360dialog.sh
+++ b/scripts/create-templates-360dialog.sh
@@ -144,7 +144,7 @@ submit_image_template "ghali_broadcast_image" "MARKETING" \
 
 # 5. ghali_credits_refresh — UTILITY, 2 vars
 submit_template "ghali_credits_refresh" "UTILITY" \
-  '"Your {{2}} credits have been refreshed. You now have {{1}} credits for this month.\n\nReply STOP to unsubscribe from these notifications."' \
+  '"Your {{2}} credits have been refreshed. You now have {{1}} credits for this month.\n\nReply *STOP* to unsubscribe, *DELETE* to completely delete your account, or *HELP* to learn more about Ghali'\''s features."' \
   '["60", "Basic"]' || true
 
 # 6. ghali_credits_low — UTILITY, 1 var


### PR DESCRIPTION
## Summary
Update the `ghali_credits_refresh` WhatsApp template footer to include DELETE and HELP options alongside the existing STOP.

**Before:**
> Reply STOP to unsubscribe from these notifications.

**After:**
> Reply *STOP* to unsubscribe, *DELETE* to completely delete your account, or *HELP* to learn more about Ghali's features.

## Notes
- Only `scripts/create-templates-360dialog.sh` changed — no backend changes needed
- STOP, DELETE, and HELP already work as system commands
- Template must be resubmitted to 360dialog for Meta approval after merge

Closes #243

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added admin action options (STOP, DELETE, HELP) to template messages, providing users with more explicit control options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->