### PR TITLE
fix: retry media download on transient failures

### DIFF
--- a/convex/lib/whatsappSend.test.ts
+++ b/convex/lib/whatsappSend.test.ts
@@ -1,5 +1,5 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
-import { sendWhatsAppMessage, sendWhatsAppMedia, sendWhatsAppTemplate, rewriteToProxy } from "./whatsappSend";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { sendWhatsAppMessage, sendWhatsAppMedia, sendWhatsAppTemplate, rewriteToProxy, downloadMedia } from "./whatsappSend";
 
 const options = {
   apiKey: "test_api_key_123",
@@ -163,6 +163,111 @@ describe("sendWhatsAppTemplate", () => {
     await expect(
       sendWhatsAppTemplate(options, "ghali_reminder", { "1": "test" })
     ).rejects.toThrow("360dialog API error");
+  });
+});
+
+describe("downloadMedia", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("returns data on first successful attempt", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ url: "https://lookaside.fbsbx.com/file", mime_type: "image/jpeg" }), { status: 200 })
+      )
+      .mockResolvedValueOnce(new Response(new ArrayBuffer(8), { status: 200 }));
+
+    const result = await downloadMedia("api_key", "media_id_123");
+
+    expect(result).not.toBeNull();
+    expect(result?.mimeType).toBe("image/jpeg");
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
+  });
+
+  it("retries Step 2 on transient failure and succeeds on second attempt", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ url: "https://lookaside.fbsbx.com/file", mime_type: "image/jpeg" }), { status: 200 })
+      )
+      .mockResolvedValueOnce(new Response("Service Unavailable", { status: 503 }))
+      .mockResolvedValueOnce(new Response(new ArrayBuffer(8), { status: 200 }));
+
+    const promise = downloadMedia("api_key", "media_id_123");
+    await vi.runAllTimersAsync();
+    const result = await promise;
+
+    expect(result).not.toBeNull();
+    expect(result?.mimeType).toBe("image/jpeg");
+    expect(fetchSpy).toHaveBeenCalledTimes(3); // 1 meta + 2 data attempts
+  });
+
+  it("returns null when Step 2 fails all retries", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ url: "https://lookaside.fbsbx.com/file", mime_type: "image/jpeg" }), { status: 200 })
+      )
+      .mockResolvedValue(new Response("Service Unavailable", { status: 503 }));
+
+    const promise = downloadMedia("api_key", "media_id_123");
+    await vi.runAllTimersAsync();
+    const result = await promise;
+
+    expect(result).toBeNull();
+    expect(fetchSpy).toHaveBeenCalledTimes(5); // 1 meta + 4 data attempts (initial + 3 retries)
+  });
+
+  it("retries Step 1 on transient failure and succeeds on second attempt", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(new Response("Service Unavailable", { status: 503 }))
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ url: "https://lookaside.fbsbx.com/file", mime_type: "image/jpeg" }), { status: 200 })
+      )
+      .mockResolvedValueOnce(new Response(new ArrayBuffer(8), { status: 200 }));
+
+    const promise = downloadMedia("api_key", "media_id_123");
+    await vi.runAllTimersAsync();
+    const result = await promise;
+
+    expect(result).not.toBeNull();
+    expect(fetchSpy).toHaveBeenCalledTimes(3); // 2 meta attempts + 1 data
+  });
+
+  it("returns null when Step 1 fails all retries", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch")
+      .mockResolvedValue(new Response("Unauthorized", { status: 401 }));
+
+    const promise = downloadMedia("api_key", "media_id_123");
+    await vi.runAllTimersAsync();
+    const result = await promise;
+
+    expect(result).toBeNull();
+    expect(fetchSpy).toHaveBeenCalledTimes(4); // 4 meta attempts (initial + 3 retries)
+  });
+
+  it("returns null when metadata has no download URL", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify({ mime_type: "image/jpeg" }), { status: 200 })
+    );
+
+    const result = await downloadMedia("api_key", "media_id_123");
+    expect(result).toBeNull();
+  });
+
+  it("defaults mimeType to application/octet-stream when absent from metadata", async () => {
+    vi.spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ url: "https://lookaside.fbsbx.com/file" }), { status: 200 })
+      )
+      .mockResolvedValueOnce(new Response(new ArrayBuffer(4), { status: 200 }));
+
+    const result = await downloadMedia("api_key", "media_id_123");
+    expect(result?.mimeType).toBe("application/octet-stream");
   });
 });
 

--- a/convex/lib/whatsappSend.ts
+++ b/convex/lib/whatsappSend.ts
@@ -137,10 +137,39 @@ export async function sendWhatsAppTemplate(
   });
 }
 
+const MAX_RETRIES = 3;
+const RETRY_DELAYS_MS = [1000, 2000, 4000];
+
+/**
+ * Fetch with exponential backoff retry on non-2xx responses.
+ * Returns the successful Response, or null if all attempts fail.
+ */
+async function fetchWithRetry(
+  fetchFn: () => Promise<Response>,
+  label: string
+): Promise<Response | null> {
+  for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
+    const response = await fetchFn();
+    if (response.ok) return response;
+
+    if (attempt < MAX_RETRIES) {
+      console.warn(
+        `[whatsappSend] ${label} attempt ${attempt + 1} failed (${response.status}), retrying...`
+      );
+      await new Promise((r) => setTimeout(r, RETRY_DELAYS_MS[attempt]));
+    } else {
+      console.error(
+        `[whatsappSend] ${label} failed after ${MAX_RETRIES + 1} attempts: ${response.status}`
+      );
+    }
+  }
+  return null;
+}
+
 /**
  * Download media from 360dialog Cloud API.
- * Step 1: GET media URL from 360dialog
- * Step 2: Download binary data from the returned URL
+ * Step 1: GET media URL from 360dialog (with retry)
+ * Step 2: Download binary data from the returned URL (with retry)
  */
 export async function downloadMedia(
   apiKey: string,
@@ -148,19 +177,14 @@ export async function downloadMedia(
 ): Promise<{ data: ArrayBuffer; mimeType: string } | null> {
   try {
     // Step 1: Get media URL
-    const metaResponse = await fetch(
-      `${DIALOG360_BASE_URL}/${mediaId}`,
-      {
+    const metaResponse = await fetchWithRetry(
+      () => fetch(`${DIALOG360_BASE_URL}/${mediaId}`, {
         headers: { "D360-API-KEY": apiKey },
-      }
+      }),
+      "Media metadata fetch"
     );
 
-    if (!metaResponse.ok) {
-      console.error(
-        `[whatsappSend] Media metadata fetch failed: ${metaResponse.status}`
-      );
-      return null;
-    }
+    if (!metaResponse) return null;
 
     const meta = await metaResponse.json();
     const downloadUrl = meta.url;
@@ -172,16 +196,14 @@ export async function downloadMedia(
     }
 
     // Step 2: Download binary data via 360dialog proxy
-    const dataResponse = await fetch(rewriteToProxy(downloadUrl, DIALOG360_BASE_URL), {
-      headers: { "D360-API-KEY": apiKey },
-    });
+    const dataResponse = await fetchWithRetry(
+      () => fetch(rewriteToProxy(downloadUrl, DIALOG360_BASE_URL), {
+        headers: { "D360-API-KEY": apiKey },
+      }),
+      "Media download"
+    );
 
-    if (!dataResponse.ok) {
-      console.error(
-        `[whatsappSend] Media download failed: ${dataResponse.status}`
-      );
-      return null;
-    }
+    if (!dataResponse) return null;
 
     const data = await dataResponse.arrayBuffer();
     return { data, mimeType };


### PR DESCRIPTION
Add exponential backoff retry (3 retries, 1s/2s/4s delays) to both steps of `downloadMedia()` in `whatsappSend.ts` — metadata fetch (Step 1) and binary download (Step 2) — to handle 360dialog media not yet processed when the webhook fires for captioned media messages.

Fixes #248

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Media downloads now include automatic retry logic with exponential backoff to improve reliability during transient network failures.

* **Tests**
  * Expanded test coverage for media download functionality, including retry mechanisms, failure scenarios, and MIME type handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->