### PR TITLE
feat: add user activity level breakdown to admin dashboard and stats

### DIFF
--- a/app/(en)/admin/page.tsx
+++ b/app/(en)/admin/page.tsx
@@ -16,6 +16,14 @@ import { Badge } from "@/components/ui/badge";
 
 type Period = "today" | "yesterday" | "7d" | "30d";
 
+interface ActivityLevels {
+  active: number;
+  inactive7d: number;
+  inactive30d: number;
+  inactive60d: number;
+  inactive90d: number;
+}
+
 interface Stats {
   totalUsers: number;
   newUsers: number;
@@ -23,6 +31,7 @@ interface Stats {
   proUsers: number;
   basicUsers: number;
   blockedUsers: number;
+  activityLevels?: ActivityLevels;
 }
 
 interface RecentUser {
@@ -166,6 +175,45 @@ export default function AdminDashboard() {
             </CardContent>
           </Card>
         ))}
+      </div>
+
+      {/* Activity Levels */}
+      <div>
+        <h2 className="mb-4 text-lg font-semibold text-white/80">User Activity Levels</h2>
+        <div className="grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-5">
+          {(
+            [
+              { label: "Active", sublabel: "< 7 days", key: "active" as const, color: "#22c55e" },
+              { label: "Inactive 7d+", sublabel: "7–29 days", key: "inactive7d" as const, color: "#eab308" },
+              { label: "Inactive 30d+", sublabel: "30–59 days", key: "inactive30d" as const, color: "#f97316" },
+              { label: "Inactive 60d+", sublabel: "60–89 days", key: "inactive60d" as const, color: "#ef4444" },
+              { label: "Inactive 90d+", sublabel: "90+ days", key: "inactive90d" as const, color: "#6b7280" },
+            ] as const
+          ).map((bucket) => (
+            <Card
+              key={bucket.key}
+              className="border-white/[0.06] bg-white/[0.02] backdrop-blur-sm transition-all duration-300 hover:bg-white/[0.04] hover:border-white/[0.1]"
+            >
+              <CardContent className="flex items-center gap-3 pt-0">
+                <div
+                  className="h-3 w-3 shrink-0 rounded-full"
+                  style={{ backgroundColor: bucket.color }}
+                />
+                <div className="min-w-0">
+                  <p className="text-xs font-medium text-white/35 uppercase tracking-wider truncate">{bucket.label}</p>
+                  {loadingStats ? (
+                    <Skeleton className="mt-1 h-7 w-12 bg-white/[0.06]" />
+                  ) : (
+                    <p className="text-2xl font-bold tabular-nums text-white">
+                      {stats?.activityLevels?.[bucket.key] ?? 0}
+                    </p>
+                  )}
+                  <p className="text-[10px] text-white/25">{bucket.sublabel}</p>
+                </div>
+              </CardContent>
+            </Card>
+          ))}
+        </div>
       </div>
 
       {/* Recent Users */}

--- a/convex/admin.ts
+++ b/convex/admin.ts
@@ -138,6 +138,35 @@ export const getStats = internalQuery({
       (u) => u.createdAt >= dubaiDayStart
     ).length;
 
+    // Exclusive activity-level buckets (based on lastMessageAt)
+    // Reuses oneWeekAgo (7d) and oneMonthAgo (30d) from above
+    const sixtyDaysAgo = now - 60 * DAY;
+    const ninetyDaysAgo = now - 90 * DAY;
+
+    let activityActive = 0;   // messaged within last 7 days
+    let activity7d = 0;       // 7–29 days ago
+    let activity30d = 0;      // 30–59 days ago
+    let activity60d = 0;      // 60–89 days ago
+    let activity90d = 0;      // 90+ days ago
+
+    for (const u of allUsers) {
+      const last = u.lastMessageAt;
+      if (!last) {
+        // Never messaged — count as 90d+ inactive
+        activity90d++;
+      } else if (last >= oneWeekAgo) {
+        activityActive++;
+      } else if (last >= oneMonthAgo) {
+        activity7d++;
+      } else if (last >= sixtyDaysAgo) {
+        activity30d++;
+      } else if (last >= ninetyDaysAgo) {
+        activity60d++;
+      } else {
+        activity90d++;
+      }
+    }
+
     return {
       totalUsers,
       pendingAcceptance,
@@ -159,6 +188,12 @@ export const getStats = internalQuery({
       activeWeekDubai,
       activeMonthDubai,
       newTodayDubai,
+      // Activity levels (exclusive buckets)
+      activityActive,
+      activity7d,
+      activity30d,
+      activity60d,
+      activity90d,
     };
   },
 });

--- a/convex/http.ts
+++ b/convex/http.ts
@@ -431,6 +431,13 @@ http.route({
         proUsers: all.proUsers,
         basicUsers: all.basicUsers,
         blockedUsers: all.blockedUsers,
+        activityLevels: {
+          active: all.activityActive,
+          inactive7d: all.activity7d,
+          inactive30d: all.activity30d,
+          inactive60d: all.activity60d,
+          inactive90d: all.activity90d,
+        },
       }),
       { status: 200, headers: { "Content-Type": "application/json" } },
     );

--- a/convex/lib/adminCommands.ts
+++ b/convex/lib/adminCommands.ts
@@ -79,6 +79,12 @@ export async function handleAdminCommand(
         activeWeekDubai: number;
         activeMonthDubai: number;
         newTodayDubai: number; // since Dubai midnight — different from newToday (rolling 24h)
+        // Activity levels (exclusive buckets)
+        activityActive: number;
+        activity7d: number;
+        activity30d: number;
+        activity60d: number;
+        activity90d: number;
       };
       return {
         response: await renderSystemMessage(
@@ -95,6 +101,11 @@ export async function handleAdminCommand(
             activeMonthDubai: stats.activeMonthDubai,
             newTodayDubai: stats.newTodayDubai,
             proUsers: stats.proUsers,
+            activityActive: stats.activityActive,
+            activity7d: stats.activity7d,
+            activity30d: stats.activity30d,
+            activity60d: stats.activity60d,
+            activity90d: stats.activity90d,
           },
           userMessage
         ),

--- a/convex/templates.ts
+++ b/convex/templates.ts
@@ -319,6 +319,13 @@ Active: {{activeWeekDubai}}
 *This Month (Dubai)*
 Active: {{activeMonthDubai}}
 
+*User Activity Levels*
+🟢 Active (7d): {{activityActive}}
+🟡 Inactive 7d+: {{activity7d}}
+🟠 Inactive 30d+: {{activity30d}}
+🔴 Inactive 60d+: {{activity60d}}
+⚫ Inactive 90d+: {{activity90d}}
+
 *All Time*
 Users: {{totalUsers}} | Pending Acceptance: {{pendingAcceptance}} | Pro: {{proUsers}}`,
     variables: [
@@ -330,6 +337,11 @@ Users: {{totalUsers}} | Pending Acceptance: {{pendingAcceptance}} | Pro: {{proUs
       "activeMonth",
       "activeWeekDubai",
       "activeMonthDubai",
+      "activityActive",
+      "activity7d",
+      "activity30d",
+      "activity60d",
+      "activity90d",
       "totalUsers",
       "pendingAcceptance",
       "proUsers",


### PR DESCRIPTION
## Summary
- Add exclusive user activity buckets: **Active** (<7d), **7-29d**, **30-59d**, **60-89d**, **90d+**
- New color-coded summary cards section on the admin web dashboard (green → gray severity)
- Updated `admin stats` WhatsApp command with emoji-coded activity breakdown
- Single O(n) pass over users, reuses existing time constants — no new DB queries

## Test plan
- [x] TypeScript typecheck passes
- [x] ESLint passes (0 errors)
- [x] All 833 tests pass
- [x] CodeRabbit review — no issues found
- [ ] Verify dashboard cards render correctly in browser
- [ ] Send `admin stats` via WhatsApp and confirm new section appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "User Activity Levels" dashboard block to admin stats, categorizing users by engagement status across five time buckets: Active (last 7 days), Inactive 7d+, 30d+, 60d+, and 90d+. Displays real-time user counts with loading indicators during data refresh.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->