### PR TITLE
fix: cancel scheduled tasks independently in deleteAccount

### DIFF
--- a/convex/accountControl.ts
+++ b/convex/accountControl.ts
@@ -195,6 +195,14 @@ export const deleteAccount = internalAction({
       console.error(`[accountControl] clearEverything failed:`, err);
     }
 
+    // 1b. Cancel scheduled tasks independently — must not be skipped if clearEverything fails,
+    // otherwise tasks will continue firing for a deleted user (privacy + orphan rows risk).
+    try {
+      await ctx.runMutation(internal.scheduledTasks.cancelAllUserScheduledTasks, { userId });
+    } catch (err) {
+      console.error(`[accountControl] cancelAllUserScheduledTasks failed:`, err);
+    }
+
     // 2. Delete remaining user-linked records not covered by clearEverything
     try {
       await ctx.runMutation(internal.accountControl.deleteOrphanedUserData, { userId, phone });

--- a/convex/scheduledTasks.ts
+++ b/convex/scheduledTasks.ts
@@ -764,7 +764,9 @@ export const getTask = internalQuery({
 });
 
 /**
- * Cancel and delete all scheduled tasks for a user (used by clearEverything).
+ * Cancel and delete all scheduled tasks for a user.
+ * Called by clearEverything and independently by deleteAccount to ensure
+ * tasks are always cancelled even if clearEverything fails.
  */
 export const cancelAllUserScheduledTasks = internalMutation({
   args: {


### PR DESCRIPTION
Move `cancelAllUserScheduledTasks` into its own independently-guarded step in `deleteAccount` so it runs even if `clearEverything` fails, preventing orphaned scheduled tasks from firing after account deletion.

Fixes #265

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Enhanced account deletion process to ensure all scheduled tasks are properly cancelled, even if other cleanup operations fail.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->