### PR TITLE
fix: telegram feedback mini app — launch error + submit non-functional

### DIFF
--- a/app/tg/feedback/page.tsx
+++ b/app/tg/feedback/page.tsx
@@ -20,7 +20,7 @@ function TelegramFeedbackContent() {
   const [message, setMessage] = useState("");
   const [error, setError] = useState<string | null>(null);
 
-  // Step 1: Verify Telegram identity
+  // Step 1: Detect Telegram identity (auth happens server-side on submit)
   useEffect(() => {
     if (state !== "loading") return;
 
@@ -28,28 +28,9 @@ function TelegramFeedbackContent() {
     if (webapp?.initData) {
       webapp.ready();
       webapp.expand();
-
-      (async () => {
-        try {
-          const res = await fetch("/api/tg-auth", {
-            method: "POST",
-            headers: { "Content-Type": "application/json" },
-            body: JSON.stringify({ initData: webapp.initData }),
-          });
-
-          if (!res.ok) {
-            setState("error");
-            setError("Could not verify your identity. Please try again.");
-            return;
-          }
-
-          setInitData(webapp.initData);
-          setState("form");
-        } catch {
-          setState("error");
-          setError("Connection error. Please try again.");
-        }
-      })();
+      // eslint-disable-next-line react-hooks/set-state-in-effect -- read external system (Telegram WebApp) then sync to React state
+      setInitData(webapp.initData);
+      setState("form"); // eslint-disable-line react-hooks/set-state-in-effect
       return;
     }
 
@@ -57,15 +38,14 @@ function TelegramFeedbackContent() {
     if (process.env.NODE_ENV === "development") {
       const devId = new URLSearchParams(window.location.search).get("telegramId");
       if (devId) {
-        // eslint-disable-next-line react-hooks/set-state-in-effect -- dev-only shortcut, tree-shaken in production
         setDevTelegramId(devId);
-        setInitData("dev_mode"); // eslint-disable-line react-hooks/set-state-in-effect
-        setState("form"); // eslint-disable-line react-hooks/set-state-in-effect
+        setInitData("dev_mode");
+        setState("form");
         return;
       }
     }
 
-    setState("not_telegram"); // eslint-disable-line react-hooks/set-state-in-effect
+    setState("not_telegram");
   }, [state]);
 
   const handleSubmit = async () => {
@@ -132,7 +112,7 @@ function TelegramFeedbackContent() {
               message={error || "Something went wrong."}
               onRetry={() => {
                 setError(null);
-                setState("form");
+                setState("loading");
               }}
             />
           )}


### PR DESCRIPTION
Fixes #292

**Bug 1 (launch error):** Removed the pre-flight `/api/tg-auth` fetch from the loading effect. The pre-flight call used a strict 5-minute `auth_date` window that caused false failures. Identity is already validated server-side by `/api/tg-feedback` on submit (30-min window).

**Bug 2 (submit does nothing):** Consequence of Bug 1 — `initData` was never set when auth failed, causing the `handleSubmit` guard (`!initData`) to silently exit. Fixed by setting `initData` directly from `window.Telegram.WebApp.initData` in the effect.

Also changed retry from `setState('form')` —> `setState('loading')` so the detection logic re-runs cleanly on any future error.

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error recovery flow: when authentication fails, the app now returns to the initialization state rather than the form, ensuring proper re-validation before allowing retry attempts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->