### PR TITLE
fix: always track media files regardless of messageSid for Telegram/360dialog

### DIFF
--- a/convex/lib/media.test.ts
+++ b/convex/lib/media.test.ts
@@ -18,6 +18,7 @@ import {
   getFormatFromMime,
   MEDIA_CATEGORY_PREFIX_MAP,
   inferMimeTypeFromFilename,
+  resolveMediaRef,
 } from "./media";
 
 describe("normalizeMimeType", () => {
@@ -600,5 +601,33 @@ describe("inferMimeTypeFromFilename", () => {
 
   it("handles filenames with multiple dots", () => {
     expect(inferMimeTypeFromFilename("my.report.2024.csv")).toBe("text/csv");
+  });
+});
+
+describe("resolveMediaRef", () => {
+  it("returns messageSid when provided", () => {
+    expect(resolveMediaRef("SM123abc", "whatsapp", "storageId1")).toBe("SM123abc");
+  });
+
+  it("falls back to inbound-{storageId} when messageSid and channel are both undefined", () => {
+    expect(resolveMediaRef(undefined, undefined, "storageId1")).toBe("inbound-storageId1");
+  });
+
+  it("falls back to telegram-{storageId} when channel is telegram and messageSid is missing", () => {
+    expect(resolveMediaRef(undefined, "telegram", "storageId2")).toBe("telegram-storageId2");
+  });
+
+  it("falls back to whatsapp-{storageId} when channel is whatsapp and messageSid is missing", () => {
+    expect(resolveMediaRef(undefined, "whatsapp", "storageId3")).toBe("whatsapp-storageId3");
+  });
+
+  it("falls back when messageSid is null", () => {
+    expect(resolveMediaRef(null, "telegram", "storageId4")).toBe("telegram-storageId4");
+  });
+
+  it("generated ref includes storageId ensuring uniqueness per upload", () => {
+    const ref1 = resolveMediaRef(null, "telegram", "aaa");
+    const ref2 = resolveMediaRef(null, "telegram", "bbb");
+    expect(ref1).not.toBe(ref2);
   });
 });

--- a/convex/lib/media.ts
+++ b/convex/lib/media.ts
@@ -288,6 +288,22 @@ export function inferMimeTypeFromFilename(
 // ============================================================================
 
 /**
+ * Build a media tracking reference for a received file.
+ *
+ * Uses messageSid if present (Twilio/WhatsApp legacy). For Telegram and
+ * 360dialog WhatsApp where messageSid is always null, generates a
+ * channel-agnostic unique ref from channel + storageId so that files are
+ * always registered in mediaFiles and ownership checks pass.
+ */
+export function resolveMediaRef(
+  messageSid: string | null | undefined,
+  channel: string | null | undefined,
+  storageId: string
+): string {
+  return messageSid ?? `${channel ?? "inbound"}-${storageId}`;
+}
+
+/**
  * Convert ArrayBuffer to base64 string.
  * Browser-compatible (no Node.js Buffer).
  */

--- a/convex/messages.ts
+++ b/convex/messages.ts
@@ -15,6 +15,7 @@ import {
   isSupportedMediaType,
   isRagIndexable,
   isVoiceNote,
+  resolveMediaRef,
 } from "./lib/media";
 import { CREDITS_BASIC, CREDITS_PRO, CREDITS_LOW_THRESHOLD, MEDIA_RETENTION_MS, SESSION_GAP_MS } from "./constants";
 import { getRecapInstruction } from "./lib/engagementRecap";
@@ -841,16 +842,14 @@ export const generateResponse = internalAction({
       }
 
       // Track voice note in mediaFiles with transcript for future reply-to-voice
-      if (messageSid) {
-        await ctx.runMutation(internal.mediaStorage.trackMediaFile, {
-          userId: typedUserId,
-          storageId: voiceResult.storageId,
-          messageSid,
-          mediaType: mediaContentType,
-          expiresAt: Date.now() + MEDIA_RETENTION_MS,
-          transcript: voiceResult.transcript,
-        });
-      }
+      await ctx.runMutation(internal.mediaStorage.trackMediaFile, {
+        userId: typedUserId,
+        storageId: voiceResult.storageId,
+        messageSid: resolveMediaRef(messageSid, channel, voiceResult.storageId),
+        mediaType: mediaContentType,
+        expiresAt: Date.now() + MEDIA_RETENTION_MS,
+        transcript: voiceResult.transcript,
+      });
 
       // Track voice note feature usage
       await ctx.scheduler.runAfter(0, internal.analytics.trackFeatureUsed, {
@@ -972,11 +971,11 @@ export const generateResponse = internalAction({
       // For Telegram: processMedia returns storageId=null (isReprocessing=true),
       // so fall back to telegramStorageId which was set during the download step.
       const mediaStorageId = storageId ?? telegramStorageId;
-      if (messageSid && mediaStorageId) {
+      if (mediaStorageId) {
         await ctx.runMutation(internal.mediaStorage.trackMediaFile, {
           userId: typedUserId,
           storageId: mediaStorageId,
-          messageSid,
+          messageSid: resolveMediaRef(messageSid, channel, mediaStorageId),
           mediaType: mediaContentType,
           expiresAt: Date.now() + MEDIA_RETENTION_MS,
         });


### PR DESCRIPTION
Fixes #300

## Root Cause
`messageSid` is a Twilio-only concept. For Telegram (always `null`) and 360dialog WhatsApp (no `messageSid`), the guard `if (messageSid && mediaStorageId)` silently skipped `trackMediaFile`, so uploaded images were never registered in `mediaFiles`. The ownership check in `getStorageUrl` then returned `null` — causing the "technical issue with file reference" error for 100% of Telegram image edits.

## Changes
- **`convex/lib/media.ts`** — New `resolveMediaRef()` helper: uses `messageSid` when present (Twilio legacy), falls back to `telegram-<storageId>` / `inbound-<storageId>` otherwise
- **`convex/messages.ts`** — Removed `messageSid &&` guard from both `trackMediaFile` call sites (images/docs + voice notes)
- **`convex/lib/media.test.ts`** — 6 new unit tests covering all channel scenarios

## Test Results
890 tests passing ✅

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved media file identification system that generates consistent references for tracking media ownership and files across all channels, including those that don't provide message IDs.

* **Tests**
  * Added comprehensive test coverage for the media reference resolution functionality across various input scenarios and channel types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->