### PR TITLE
fix: style transfer uses reference image instead of generating from scratch

### DIFF
--- a/convex/agent.ts
+++ b/convex/agent.ts
@@ -120,6 +120,8 @@ IMAGE GENERATION & EDITING:
 - Explicit edit requests: "add hot air balloons to this", "make it darker", "remove the background", "change the sky to sunset", "modify this image", "edit my last image"
 - IMPLICIT edit requests — when the user's follow-up uses a pronoun ("it", "this", "that") or contextually refers to a recently generated image: "have a girl ride it", "put a sunset behind it", "add someone to it", "now make it blue", "give it wings". If the prior conversation includes an image generation, treat these as edit requests: call resolveMedia to get the storageId and pass it to generateImage.
 - NEVER generate a brand new image when intent is clearly an edit of a prior image — always retrieve the reference via resolveMedia when no storageId is in context.
+- SAME-MESSAGE IMAGE EDITING: When a user sends an image AND a style/transformation request in the SAME message (e.g. "Make ghibli style", "turn this into manga", "cartoon version", "oil painting style"), ALWAYS treat it as an edit request. Pass the [File storageId: ...] from your context as referenceImageStorageId to generateImage. Do NOT generate a new image from scratch.
+- Style transformations when sent with an image: "make ghibli style", "make manga", "turn into cartoon", "oil painting version", "watercolor style", "pixel art", "anime style", "sketch", "retro style"
 
 WEB SEARCH:
 - You have access to Google Search for real-time information

--- a/convex/images.ts
+++ b/convex/images.ts
@@ -94,6 +94,9 @@ export const generateAndStoreImage = internalAction({
           chunks.push(String.fromCharCode(...imageBytes.subarray(i, i + chunkSize)));
         }
         const base64Image = btoa(chunks.join(""));
+        // When editing with a reference image, wrap with style-transfer instruction
+        // so Gemini preserves the subject's likeness instead of generating a new scene
+        const effectivePrompt = `Transform the person/subject in this image: ${prompt}. Preserve their face, appearance, and likeness.`;
         contents = [
           {
             role: "user" as const,
@@ -104,7 +107,7 @@ export const generateAndStoreImage = internalAction({
                   mimeType: referenceMimeType,
                 },
               },
-              { text: prompt },
+              { text: effectivePrompt },
             ],
           },
         ];


### PR DESCRIPTION
Fixes the bug where style transformation requests (Ghibli, manga, cartoon, etc.) generate a new image instead of transforming the sent photo.

**Changes:**
- `convex/agent.ts`: Add SAME-MESSAGE IMAGE EDITING rule and style transformation examples to system prompt
- `convex/images.ts`: Wrap prompt with style-transfer instruction when editing with a reference image

Closes #303

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed image editing to correctly recognize style transformation requests sent alongside images as edits rather than new image generation.

* **New Features**
  * Enhanced style transformation support: Ghibli, Manga, Cartoon, Oil Painting, Watercolor, Pixel Art, Anime, Sketch, and Retro styles now properly reference and preserve the original image during transformations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->