### PR TITLE
fix: follow-up image edits fail — agent instruction ambiguity + diagnostic logging

### DIFF
--- a/convex/agent.ts
+++ b/convex/agent.ts
@@ -116,10 +116,13 @@ IMAGE GENERATION & EDITING:
 - Pass the user's EXACT words as the prompt — do NOT rewrite, embellish, or add details. Gemini handles prompt interpretation.
 - ALWAYS use 9:16 (portrait) aspect ratio unless the user explicitly asks for landscape or square — WhatsApp users are on phones
 - If the model declines, tell the user politely and suggest rephrasing
-- IMAGE EDITING: when users want to modify, edit, or add to an EXISTING image (theirs or previously generated), pass the image's storageId to generateImage via referenceImageStorageId. The storageId is available in the message context (e.g. "[File storageId: ...]"). If no storageId is in the context, call resolveMedia (mediaCategory: "image") first to get the storageId, then pass it to generateImage.
+- IMAGE EDITING: when users want to modify, edit, or add to an EXISTING image (theirs or previously generated), pass the image's storageId to generateImage via referenceImageStorageId.
+  - For user-sent images in the CURRENT message: use the [File storageId: ...] annotation already in your context.
+  - For FOLLOW-UP edits of a previously generated image (user sends ONLY text, no attachment — e.g. "Add balloons", "Make it darker", "Now make it Ghibli"): ALWAYS call resolveMedia(mediaCategory: "image") first. Do NOT attempt to parse or extract storageId from previous tool results in conversation history — use resolveMedia as the single reliable source.
+  - For follow-up edits of a previously UPLOADED image (user sent image earlier, now sends only text): also call resolveMedia(mediaCategory: "image") first.
 - Explicit edit requests: "add hot air balloons to this", "make it darker", "remove the background", "change the sky to sunset", "modify this image", "edit my last image"
-- IMPLICIT edit requests — when the user's follow-up uses a pronoun ("it", "this", "that") or contextually refers to a recently generated image: "have a girl ride it", "put a sunset behind it", "add someone to it", "now make it blue", "give it wings". If the prior conversation includes an image generation, treat these as edit requests: call resolveMedia to get the storageId and pass it to generateImage.
-- NEVER generate a brand new image when intent is clearly an edit of a prior image — always retrieve the reference via resolveMedia when no storageId is in context.
+- IMPLICIT edit requests — when the user's follow-up uses a pronoun ("it", "this", "that") or contextually refers to a recently generated image: "have a girl ride it", "put a sunset behind it", "add someone to it", "now make it blue", "give it wings". If the prior conversation includes an image generation, treat these as edit requests: call resolveMedia(mediaCategory: "image") to get the storageId and pass it to generateImage.
+- NEVER generate a brand new image when intent is clearly an edit of a prior image — always call resolveMedia first to retrieve the reference storageId.
 - SAME-MESSAGE IMAGE EDITING: When a user sends an image AND a style/transformation request in the SAME message (e.g. "Make ghibli style", "turn this into manga", "cartoon version", "oil painting style"), ALWAYS treat it as an edit request. Pass the [File storageId: ...] from your context as referenceImageStorageId to generateImage. Do NOT generate a new image from scratch.
 - Style transformations when sent with an image: "make ghibli style", "make manga", "turn into cartoon", "oil painting version", "watercolor style", "pixel art", "anime style", "sketch", "retro style"
 
@@ -553,7 +556,7 @@ const generateImage = createTool({
       .string()
       .optional()
       .describe(
-        "Convex storage ID of an existing image to edit/modify. Pass this when the user wants to modify an existing image — including implicit requests using pronouns like 'it', 'this', 'that' that refer to a recently generated image (e.g. 'add hot air balloons to this', 'make it darker', 'have a girl ride it'). Get the storageId from the message context [File storageId: ...] or by calling resolveMedia first."
+        "Convex storage ID of an existing image to edit/modify. Pass this when the user wants to modify an existing image — including implicit requests using pronouns like 'it', 'this', 'that' that refer to a recently generated image (e.g. 'add hot air balloons to this', 'make it darker', 'have a girl ride it'). For same-message edits: use the [File storageId: ...] from your context. For follow-up edits (user sends only text, no attachment): ALWAYS call resolveMedia(mediaCategory: 'image') first to get the storageId — never extract from previous tool results."
       ),
   }),
   handler: async (ctx, { prompt, aspectRatio, referenceImageStorageId }): Promise<string> => {

--- a/convex/imageStorage.test.ts
+++ b/convex/imageStorage.test.ts
@@ -96,3 +96,122 @@ describe("getGeneratedImageUrl", () => {
     expect(url).toBeNull();
   });
 });
+
+describe("getRecentGeneratedImages", () => {
+  it("returns the most recent generated image for a user", async () => {
+    const t = convexTest(schema, modules);
+    const userId = await createTestUser(t);
+    const storageId = await storeBlob(t);
+
+    await t.run(async (ctx) => {
+      await ctx.db.insert("generatedImages", {
+        userId,
+        storageId,
+        expiresAt: Date.now() + 86400000,
+      });
+    });
+
+    const images = await t.query(internal.imageStorage.getRecentGeneratedImages, {
+      userId,
+    });
+
+    expect(images).toHaveLength(1);
+    expect(images[0]!.storageId).toEqual(storageId);
+    expect(images[0]!.mediaType).toBe("image/png");
+    expect(typeof images[0]!.createdAt).toBe("number");
+  });
+
+  it("returns empty array when no generated images exist for user", async () => {
+    const t = convexTest(schema, modules);
+    const userId = await createTestUser(t);
+
+    const images = await t.query(internal.imageStorage.getRecentGeneratedImages, {
+      userId,
+    });
+
+    expect(images).toHaveLength(0);
+  });
+
+  it("does not return another user's generated images", async () => {
+    const t = convexTest(schema, modules);
+    const userId1 = await createTestUser(t, "+971501234567");
+    const userId2 = await createTestUser(t, "+971509999999");
+    const storageId = await storeBlob(t);
+
+    await t.run(async (ctx) => {
+      await ctx.db.insert("generatedImages", {
+        userId: userId1,
+        storageId,
+        expiresAt: Date.now() + 86400000,
+      });
+    });
+
+    const images = await t.query(internal.imageStorage.getRecentGeneratedImages, {
+      userId: userId2,
+    });
+
+    expect(images).toHaveLength(0);
+  });
+
+  it("respects the limit parameter", async () => {
+    const t = convexTest(schema, modules);
+    const userId = await createTestUser(t);
+
+    // Insert 3 images
+    const storageIds: Id<"_storage">[] = [];
+    for (let i = 0; i < 3; i++) {
+      const sid = await storeBlob(t);
+      storageIds.push(sid);
+      await t.run(async (ctx) => {
+        await ctx.db.insert("generatedImages", {
+          userId,
+          storageId: sid,
+          expiresAt: Date.now() + 86400000,
+        });
+      });
+    }
+
+    const images = await t.query(internal.imageStorage.getRecentGeneratedImages, {
+      userId,
+      limit: 2,
+    });
+
+    expect(images).toHaveLength(2);
+  });
+
+  it("returns images sorted most-recent-first", async () => {
+    const t = convexTest(schema, modules);
+    const userId = await createTestUser(t);
+
+    // Insert two images sequentially so they have distinct creationTimes
+    const sid1 = await storeBlob(t);
+    await t.run(async (ctx) => {
+      await ctx.db.insert("generatedImages", {
+        userId,
+        storageId: sid1,
+        expiresAt: Date.now() + 86400000,
+      });
+    });
+
+    const sid2 = await storeBlob(t);
+    await t.run(async (ctx) => {
+      await ctx.db.insert("generatedImages", {
+        userId,
+        storageId: sid2,
+        expiresAt: Date.now() + 86400000,
+      });
+    });
+
+    const images = await t.query(internal.imageStorage.getRecentGeneratedImages, {
+      userId,
+      limit: 2,
+    });
+
+    expect(images).toHaveLength(2);
+    // Most recent (sid2) should come first
+    expect(images[0]!.storageId).toEqual(sid2);
+    expect(images[1]!.storageId).toEqual(sid1);
+    // Verify descending order
+    expect(images[0]!.createdAt).toBeGreaterThanOrEqual(images[1]!.createdAt);
+  });
+});

--- a/convex/images.ts
+++ b/convex/images.ts
@@ -60,23 +60,41 @@ export const generateAndStoreImage = internalAction({
       if (refStorageId) {
         // Ownership check: verify the storageId belongs to this user
         // (could be in mediaFiles from uploads or generatedImages from prior generations)
+        console.log(
+          `[generateAndStoreImage] Ownership check — refStorageId: ${refStorageId}, userId: ${userId}`
+        );
         const [mediaUrl, generatedUrl] = await Promise.all([
           ctx.runQuery(internal.mediaStorage.getStorageUrl, { storageId: refStorageId, userId }),
           ctx.runQuery(internal.imageStorage.getGeneratedImageUrl, { storageId: refStorageId, userId }),
         ]);
+        console.log(
+          `[generateAndStoreImage] Ownership result — mediaUrl: ${mediaUrl ? "found" : "null"}, generatedUrl: ${generatedUrl ? "found" : "null"}`
+        );
         if (!mediaUrl && !generatedUrl) {
+          console.error(
+            `[generateAndStoreImage] Ownership FAILED — refStorageId: ${refStorageId} not found in mediaFiles or generatedImages for userId: ${userId}`
+          );
           return { success: false, error: "Reference image not found or does not belong to you." };
         }
 
         // Fetch the reference image from Convex storage
         const imageBlob = await ctx.storage.get(refStorageId);
         if (!imageBlob) {
+          console.error(
+            `[generateAndStoreImage] Storage fetch FAILED — refStorageId: ${refStorageId} not found in storage`
+          );
           return { success: false, error: "Reference image not found in storage." };
         }
 
         // Validate MIME type — only images can be used as references
         const referenceMimeType = imageBlob.type || "application/octet-stream";
+        console.log(
+          `[generateAndStoreImage] Reference image MIME type: ${referenceMimeType}, size: ${imageBlob.size} bytes`
+        );
         if (!referenceMimeType.startsWith("image/")) {
+          console.error(
+            `[generateAndStoreImage] MIME type check FAILED — expected image/*, got: ${referenceMimeType}`
+          );
           return { success: false, error: "Reference file must be an image." };
         }
 
@@ -127,6 +145,9 @@ export const generateAndStoreImage = internalAction({
       }
 
       if (!imageBase64 || !mimeType) {
+        console.error(
+          `[generateAndStoreImage] Gemini returned no image — isEditing: ${isEditing}, candidates: ${response.candidates?.length ?? 0}, parts: ${JSON.stringify(response.candidates?.[0]?.content?.parts?.map((p) => ({ hasText: !!p.text, hasInlineData: !!p.inlineData })) ?? [])}`
+        );
         if (user) {
           await ctx.scheduler.runAfter(0, internal.analytics.trackImageGenerated, {
             phone: user.phone,


### PR DESCRIPTION
Fixes #312

## Summary

- `convex/agent.ts`: Rewrote `IMAGE EDITING` instruction to require `resolveMedia` for all follow-up edits (no attachment), removing the ambiguous "extract from conversation history" path that caused Gemini to confuse `imageUrl` with `storageId`
- `convex/images.ts`: Add diagnostic logging at ownership check, storage fetch, MIME type validation, and Gemini no-image response
- `convex/imageStorage.test.ts`: Add 5 tests for `getRecentGeneratedImages`

## Test plan

- [x] All existing tests pass
- [x] New `getRecentGeneratedImages` tests pass (8/8 in imageStorage.test.ts)
- [ ] Manual: generate image in Telegram → send follow-up edit request → verify edit succeeds

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced image editing workflow with improved handling of follow-up edits to previously generated images.

* **Tests**
  * Added comprehensive test coverage for retrieving recent generated images, including user isolation, limit parameters, and sort ordering.

* **Improvements**
  * Improved reliability of image generation operations with enhanced diagnostic logging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->