### PR TITLE
fix(images): omit imageConfig when editing to fix Gemini API rejection

### DIFF
--- a/convex/images.ts
+++ b/convex/images.ts
@@ -125,7 +125,7 @@ export const generateAndStoreImage = internalAction({
         contents,
         config: {
           responseModalities: ["TEXT", "IMAGE"],
-          imageConfig: { aspectRatio },
+          ...(isEditing ? {} : { imageConfig: { aspectRatio } }),
         },
       });
 


### PR DESCRIPTION
When referenceImageStorageId is set (style transfer / editing), do not pass imageConfig.aspectRatio to the Gemini API. Forcing an output aspect ratio conflicts with pixel-level image transformation and causes the API to reject the request.

Closes #318

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed image processing behavior to correctly handle aspect ratio settings during image editing operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->