### PR TITLE
fix(images): fallback to image/jpeg when blob type is application/octet-stream

### DIFF
--- a/convex/images.ts
+++ b/convex/images.ts
@@ -88,8 +88,14 @@ export const generateAndStoreImage = internalAction({
           return { success: false, error: "Reference image not found in storage." };
         }
 
-        // Validate MIME type — only images can be used as references
-        const referenceMimeType = imageBlob.type || "application/octet-stream";
+        // Validate MIME type — only images can be used as references.
+        // If blob has no meaningful MIME type (Convex stores Telegram images as
+        // application/octet-stream), default to image/jpeg — Telegram photos are always JPEG
+        // and the calling code already validated isImageType before dispatching here.
+        const referenceMimeType =
+          imageBlob.type && imageBlob.type !== "application/octet-stream"
+            ? imageBlob.type
+            : "image/jpeg";
         console.log(
           `[generateAndStoreImage] Reference image MIME type: ${referenceMimeType}, size: ${imageBlob.size} bytes`
         );


### PR DESCRIPTION
When Convex stores Telegram images, the blob MIME type is `application/octet-stream` instead of `image/jpeg`, causing the MIME type check in `generateAndStoreImage` to fail early for all Telegram images.

Default to `image/jpeg` when the blob type is `application/octet-stream` or empty, unblocking the entire image editing flow for Telegram users.

Fixes #329

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved MIME type detection for images lacking proper metadata. Images without meaningful MIME type information are now correctly processed as JPEG format, enhancing compatibility with images from certain sources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->