### PR TITLE
fix: atomic credit check+deduct to prevent race condition

### DIFF
--- a/convex/credits.test.ts
+++ b/convex/credits.test.ts
@@ -84,6 +84,137 @@ describe("checkCredit", () => {
   });
 });
 
+describe("checkAndDeductCredit", () => {
+  it("atomically deducts 1 credit and returns available", async () => {
+    const t = convexTest(schema, modules);
+
+    const userId = await t.mutation(internal.users.findOrCreateUser, {
+      phone: "+971501234567",
+    });
+
+    const result = await t.mutation(internal.credits.checkAndDeductCredit, {
+      userId,
+      message: "What is AI?",
+    });
+
+    expect(result.status).toBe("available");
+    expect(result.credits).toBe(59);
+
+    const user = await t.query(internal.users.getUser, { userId });
+    expect(user!.credits).toBe(59);
+  });
+
+  it("returns exhausted and does not deduct when credits = 0", async () => {
+    const t = convexTest(schema, modules);
+
+    const userId = await t.mutation(internal.users.findOrCreateUser, {
+      phone: "+971501234567",
+    });
+
+    await t.mutation(internal.users.updateUser, {
+      userId,
+      fields: { credits: 0 },
+    });
+
+    const result = await t.mutation(internal.credits.checkAndDeductCredit, {
+      userId,
+      message: "Hello",
+    });
+
+    expect(result.status).toBe("exhausted");
+    expect(result.credits).toBe(0);
+
+    const user = await t.query(internal.users.getUser, { userId });
+    expect(user!.credits).toBe(0);
+  });
+
+  it("system commands return free and do not deduct", async () => {
+    const t = convexTest(schema, modules);
+
+    const userId = await t.mutation(internal.users.findOrCreateUser, {
+      phone: "+971501234567",
+    });
+
+    const result = await t.mutation(internal.credits.checkAndDeductCredit, {
+      userId,
+      message: "credits",
+    });
+
+    expect(result.status).toBe("free");
+
+    const user = await t.query(internal.users.getUser, { userId });
+    expect(user!.credits).toBe(60);
+  });
+
+  it("prevents race condition: second call on 1-credit balance returns exhausted", async () => {
+    const t = convexTest(schema, modules);
+
+    const userId = await t.mutation(internal.users.findOrCreateUser, {
+      phone: "+971501234567",
+    });
+
+    await t.mutation(internal.users.updateUser, {
+      userId,
+      fields: { credits: 1 },
+    });
+
+    const first = await t.mutation(internal.credits.checkAndDeductCredit, {
+      userId,
+      message: "Hello",
+    });
+    expect(first.status).toBe("available");
+    expect(first.credits).toBe(0);
+
+    const second = await t.mutation(internal.credits.checkAndDeductCredit, {
+      userId,
+      message: "Hello again",
+    });
+    expect(second.status).toBe("exhausted");
+    expect(second.credits).toBe(0);
+
+    const user = await t.query(internal.users.getUser, { userId });
+    expect(user!.credits).toBe(0);
+  });
+});
+
+describe("refundCredit", () => {
+  it("adds 1 credit back after deduction", async () => {
+    const t = convexTest(schema, modules);
+
+    const userId = await t.mutation(internal.users.findOrCreateUser, {
+      phone: "+971501234567",
+    });
+
+    await t.mutation(internal.credits.checkAndDeductCredit, {
+      userId,
+      message: "Hello",
+    });
+
+    const result = await t.mutation(internal.credits.refundCredit, { userId });
+
+    expect(result.credits).toBe(60);
+
+    const user = await t.query(internal.users.getUser, { userId });
+    expect(user!.credits).toBe(60);
+  });
+
+  it("does not exceed the tier cap when refunding", async () => {
+    const t = convexTest(schema, modules);
+
+    const userId = await t.mutation(internal.users.findOrCreateUser, {
+      phone: "+971501234567",
+    });
+
+    // Already at cap
+    const result = await t.mutation(internal.credits.refundCredit, { userId });
+
+    expect(result.credits).toBe(60);
+
+    const user = await t.query(internal.users.getUser, { userId });
+    expect(user!.credits).toBe(60);
+  });
+});
+
 describe("deductCredit", () => {
   it("deducts 1 credit from user", async () => {
     const t = convexTest(schema, modules);

--- a/convex/credits.ts
+++ b/convex/credits.ts
@@ -44,6 +44,67 @@ export const checkCredit = internalQuery({
 });
 
 /**
+ * Atomically check credit availability and deduct 1 credit in a single transaction.
+ * Prevents the race condition where concurrent checkCredit queries all see the same
+ * stale balance, allowing multiple requests to exceed the credit cap.
+ *
+ * Returns: { status: "available" | "exhausted" | "free", credits: number }
+ * - "available": credit was deducted; credits = new balance
+ * - "exhausted": no credits; nothing deducted; credits = 0
+ * - "free": system/admin command; nothing deducted; credits = current balance
+ */
+export const checkAndDeductCredit = internalMutation({
+  args: {
+    userId: v.id("users"),
+    message: v.string(),
+  },
+  handler: async (ctx, { userId, message }) => {
+    const user = await ctx.db.get(userId);
+    if (!user) {
+      throw new Error("User not found");
+    }
+
+    if (isSystemCommand(message)) {
+      return { status: "free" as const, credits: user.credits };
+    }
+
+    if (isAdminCommand(message) && user.isAdmin) {
+      return { status: "free" as const, credits: user.credits };
+    }
+
+    if (user.credits <= 0) {
+      return { status: "exhausted" as const, credits: 0 };
+    }
+
+    const newCredits = Math.max(0, user.credits - 1);
+    await ctx.db.patch(userId, { credits: newCredits });
+    return { status: "available" as const, credits: newCredits };
+  },
+});
+
+/**
+ * Refund 1 credit to a user. Call when an AI response fails after a credit was
+ * already deducted by checkAndDeductCredit, so the user is not charged for errors.
+ */
+export const refundCredit = internalMutation({
+  args: {
+    userId: v.id("users"),
+  },
+  handler: async (ctx, { userId }) => {
+    const user = await ctx.db.get(userId);
+    if (!user) {
+      throw new Error("User not found");
+    }
+
+    const tier = user.tier ?? "basic";
+    const cap = tier === "pro" ? CREDITS_PRO : CREDITS_BASIC;
+    const newCredits = Math.min(cap, user.credits + 1);
+    await ctx.db.patch(userId, { credits: newCredits });
+    return { credits: newCredits };
+  },
+});
+
+/**
  * Deduct 1 credit from a user. Call only after a successful AI response.
  * Returns the new credit balance.
  */

--- a/convex/messages.ts
+++ b/convex/messages.ts
@@ -553,8 +553,9 @@ export const generateResponse = internalAction({
       // Fall through to AI with onboarding already marked done (nextStep: null)
     }
 
-    // Check credit availability (no deduction yet — only deduct after successful response)
-    const creditCheck = await ctx.runQuery(internal.credits.checkCredit, {
+    // Atomically check and deduct credit in one transaction to prevent race conditions.
+    // If deduction succeeds (status "available") but the AI later fails, refundCredit is called.
+    const creditCheck = await ctx.runMutation(internal.credits.checkAndDeductCredit, {
       userId: typedUserId,
       message: messageForCredits,
     });
@@ -806,6 +807,10 @@ export const generateResponse = internalAction({
       { userId: typedUserId }
     );
     if (!rateCheck.ok) {
+      // Refund the credit deducted above — rate-limited requests don't consume credits
+      if (creditCheck.status === "available") {
+        await ctx.runMutation(internal.credits.refundCredit, { userId: typedUserId });
+      }
       const message = fillTemplate(TEMPLATES.rate_limited.template, {
         retryAfterSeconds: rateCheck.retryAfterSeconds,
       });
@@ -1060,10 +1065,12 @@ export const generateResponse = internalAction({
             clearTraceId();
           }
 
-          // Deduct credit and track analytics on success
+          // Credit was already deducted atomically at the start. Refund on failure.
+          if (!editSucceeded) {
+            await ctx.runMutation(internal.credits.refundCredit, { userId: typedUserId });
+          }
           if (editSucceeded) {
-            await ctx.runMutation(internal.credits.deductCredit, { userId: typedUserId });
-            const newCredits = Math.max(0, user.credits - 1);
+            const newCredits = creditCheck.credits;
             await ctx.scheduler.runAfter(0, internal.analytics.trackCreditUsed, {
               phone: user.phone,
               credits_remaining: newCredits,
@@ -1216,12 +1223,13 @@ export const generateResponse = internalAction({
       clearTraceId();
     }
 
-    // Only deduct credit after successful AI response
+    // Credit was already deducted atomically at the start. Refund if AI failed.
+    if (!aiSucceeded && creditCheck.status === "available") {
+      await ctx.runMutation(internal.credits.refundCredit, { userId: typedUserId });
+    }
+
     if (aiSucceeded && creditCheck.status === "available") {
-      await ctx.runMutation(internal.credits.deductCredit, {
-        userId: typedUserId,
-      });
-      const newCredits = Math.max(0, user.credits - 1);
+      const newCredits = creditCheck.credits;
       await ctx.scheduler.runAfter(0, internal.analytics.trackCreditUsed, {
         phone: user.phone,
         credits_remaining: newCredits,
@@ -1284,12 +1292,12 @@ export const generateResponse = internalAction({
     if (
       aiSucceeded &&
       creditCheck.status === "available" &&
-      (Math.max(0, user.credits - 1)) <= CREDITS_LOW_THRESHOLD &&
-      user.credits > CREDITS_LOW_THRESHOLD
+      creditCheck.credits <= CREDITS_LOW_THRESHOLD &&
+      creditCheck.credits + 1 > CREDITS_LOW_THRESHOLD
     ) {
       const lowCreditMsg = fillTemplate(
         TEMPLATES.credits_low_warning.template,
-        { credits: Math.max(0, user.credits - 1) }
+        { credits: creditCheck.credits }
       );
       if (isTelegram && chatId) {
         ctx.scheduler.runAfter(2000, internal.telegram.guardedSendKeyboard, {

--- a/convex/scheduledTasks.ts
+++ b/convex/scheduledTasks.ts
@@ -237,8 +237,9 @@ export const executeScheduledTask = internalAction({
       return;
     }
 
-    // Check credits (pass "__scheduled__" to skip system command check)
-    const creditCheck = await ctx.runQuery(internal.credits.checkCredit, {
+    // Atomically check and deduct credit in one transaction to prevent race conditions.
+    // If deduction succeeds but delivery later fails, refundCredit is called.
+    const creditCheck = await ctx.runMutation(internal.credits.checkAndDeductCredit, {
       userId: task.userId,
       message: "__scheduled__",
     });
@@ -361,6 +362,9 @@ export const executeScheduledTask = internalAction({
     }
 
     if (!aiSucceeded || !responseText) {
+      // Refund the credit deducted above — AI failure should not cost the user
+      await ctx.runMutation(internal.credits.refundCredit, { userId: task.userId });
+
       // Only notify on the FIRST consecutive AI failure (same discipline as messages.ts).
       // Suppresses notification during backoff AND on 2nd+ pre-breaker failures.
       const freshUser = await ctx.runQuery(internal.users.internalGetUser, { userId: task.userId });
@@ -517,7 +521,9 @@ export const executeScheduledTask = internalAction({
     }
 
     if (!delivered) {
-      // Delivery failed — mark error, reschedule cron, retry or disable one-off
+      // Delivery failed — refund the credit deducted at the start
+      await ctx.runMutation(internal.credits.refundCredit, { userId: task.userId });
+      // Mark error, reschedule cron, retry or disable one-off
       await ctx.runMutation(internal.scheduledTasks.markLastRun, {
         taskId,
         lastStatus: "error",
@@ -544,10 +550,7 @@ export const executeScheduledTask = internalAction({
       return;
     }
 
-    // Deduct credit after successful delivery
-    await ctx.runMutation(internal.credits.deductCredit, {
-      userId: task.userId,
-    });
+    // Credit was already deducted atomically at the start — no separate deduct needed
 
     // Mark success + clear credit notification flag
     await ctx.runMutation(internal.scheduledTasks.markLastRun, {


### PR DESCRIPTION
Fixes #339

Merge checkCredit (query) and deductCredit (mutation) into a single checkAndDeductCredit internalMutation that reads and decrements credits in one serialized transaction. Adds refundCredit for AI/delivery failure cases.

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Automatic credit refunds now trigger when operations fail.

* **Bug Fixes**
  * Improved credit deduction reliability with atomic operations.
  * Credits are refunded when errors occur during processing, preventing unintended credit loss.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->